### PR TITLE
fixing wrong statement for setting partitionOverwriteMode to DYNAMIC

### DIFF
--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -24,7 +24,7 @@
   {% else %}
       {% if strategy == 'insert_overwrite' and partition_by %}
         {% call statement() %}
-          set glue.sql.sources.partitionOverwriteMode = DYNAMIC
+          set spark.sql.sources.partitionOverwriteMode = DYNAMIC
         {% endcall %}
       {% endif %}
       {% if existing_relation_type is none %}


### PR DESCRIPTION
### Description

When running an incremental model with glue and `incremental_strategy: insert_overwrite` glue deleted all partitions except the new/overwritten partitions.

#### See example:

**usage_example model**
```
{{ config(
    materialized='incremental',
    partition_by=['event_date'],
    tags='example',
    incremental_strategy='insert_overwrite'
) }}

SELECT
    id,
    event_date
FROM {{ ref('usg_usage_example') }} WHERE event_date = date '{{ var("start_date") }}'
```

`dbt run --select +usage_example --vars '{start_date: 2022-01-01}'`

**existing partitions:**
event_date=2022-01-01

`dbt run --select +usage_example --vars '{start_date: 2022-01-02}'`

**existing partitions:**
event_date=2022-01-02

**expected partitions:**
event_date=2022-01-01
event_date=2022-01-02

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
