### PR TITLE
Override type_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
   - Updated get_relation method to return relation as dict instead of list. [Github Issue Link](https://github.com/aws-samples/dbt-glue/issues/52)
   - Added Conf param for Glue to add custom spark configuration options.
   - Updated glue.sql.sources.partitionOverwriteMode to spark.sql.sources.partitionOverwriteMode to work partition overwrite properly.
+- Override default types for STRING from TEXT to STRING

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -123,3 +123,7 @@
     {{ sql }}
   {% endcall %}
 {% endmacro %}
+
+{% macro spark__type_string() -%}
+    STRING
+{%- endmacro %}


### PR DESCRIPTION
### Description

Glue DB does not support a Type of TEXt which is the default STRING type in DBT due to it being based on the Postgres API.
This macro overrides that and sets it correctly to STRING which in turn allows use of dbt_expectations


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
