### PR TITLE
Fix partitioning on hudi when using Merge

### DIFF
--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -538,10 +538,9 @@ PARTITIONED BY ({part_list})
 
         if partition_key:
             partition_list = ','.join(partition_key)
+            hudi_partitionning = f''' 'hoodie.datasource.write.partitionpath.field': '{partition_list}', 'hoodie.datasource.hive_sync.partition_extractor_class': 'org.apache.hudi.hive.MultiPartKeysValueExtractor', 'hoodie.datasource.hive_sync.partition_fields': '{partition_list}','''
 
         begin_of_hudi_setup = f'''combinedConf = {{'className' : 'org.apache.hudi', 'hoodie.datasource.hive_sync.use_jdbc':'false', 'hoodie.datasource.write.precombine.field': 'update_hudi_ts', 'hoodie.consistency.check.enabled': 'true', 'hoodie.datasource.write.recordkey.field': '{primary_key}', 'hoodie.table.name': '{target_relation.name}', 'hoodie.datasource.hive_sync.database': '{target_relation.schema}', 'hoodie.datasource.hive_sync.table': '{target_relation.name}', 'hoodie.datasource.hive_sync.enable': 'true','''
-
-        hudi_partitionning = f''' 'hoodie.datasource.write.partitionpath.field': '{partition_list}', 'hoodie.datasource.hive_sync.partition_extractor_class': 'org.apache.hudi.hive.MultiPartKeysValueExtractor', 'hoodie.datasource.hive_sync.partition_fields': '{partition_list}','''
 
         hudi_no_partition = f''' 'hoodie.datasource.hive_sync.partition_extractor_class': 'org.apache.hudi.hive.NonPartitionedExtractor', 'hoodie.datasource.write.keygenerator.class': 'org.apache.hudi.keygen.NonpartitionedKeyGenerator','''
 
@@ -567,7 +566,7 @@ if outputDf.count() > 0:
         {begin_of_hudi_setup} {hudi_partitionning} {hudi_upsert}
         {self.hudi_write(write_mode, session, target_relation, custom_location)}
     else:
-        {begin_of_hudi_setup} {hudi_no_partition} {hudi_upsert}
+        {begin_of_hudi_setup} {hudi_partitionning} {hudi_upsert}
         {self.hudi_write(write_mode, session, target_relation, custom_location)}
         '''
         else:


### PR DESCRIPTION
resolves an issue that force the use of partitioning when using hudi with merge strategy

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

When using hudi with incremental mode and merge strategy, we are forced to use partitions. This PR allow to don't use partitions. 
### Checklist

- [ ] Test locally
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
