### PR TITLE
Fixes errors when trying to execute queries that finishes with single quote 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
-## v0.2.11 (unreleased)
+## v0.2.12 (unreleased)
+
+- Added a function to add an end space in case of single quoute at the end of a query. Ex: WHERE column='foo' [Github Issue Link](https://github.com/aws-samples/dbt-glue/issues/87)
+
+## v0.2.11
 
 - [#80](https://github.com/aws-samples/dbt-glue/pull/80): Fix default glue version on documentation
   - Changing default glue version and fixing a typo. [Github Issue Link](https://github.com/aws-samples/dbt-glue/issues/80)

--- a/dbt/adapters/glue/gluedbapi/cursor.py
+++ b/dbt/adapters/glue/gluedbapi/cursor.py
@@ -58,6 +58,16 @@ class GlueCursor:
             return sql[end + len(comment_end):]
         return sql
 
+    @classmethod
+    def add_end_space_if_single_quote(cls, sql: str):
+        """ If query finishes with single quote ('),
+        the execution of the query will fail. Ex: WHERE column='foo'
+        """
+        logger.debug("GlueCursor add_end_space_if_single_quote called")
+        if sql.endswith("'"):
+            return sql + " "
+        return sql
+
     def execute(self, sql, bindings=None):
         logger.debug("GlueCursor execute called")
         if self.closed:
@@ -65,6 +75,7 @@ class GlueCursor:
         if self._is_running:
             raise dbterrors.InternalException("CursorAlreadyRunning")
         self.sql = GlueCursor.remove_comments_header(sql)
+        self.sql = GlueCursor.add_end_space_if_single_quote(sql)
 
         self._pre()
 


### PR DESCRIPTION
resolves #87 


### Description

Added a function to add an end space in case of single quoute at the end of a query. Ex: WHERE column='foo'

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
