### PR TITLE
Allow DBT 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
+## v1.3.0 
+
+- Updated dependencies to support dbt-core 1.3.0 and switched to mainline version numbering
+
 ## v0.2.14 (unreleased)
 
 - Fix duplicates when using partitions changes with Hudi/Merge incremental materialization  [Github Issue Link](https://github.com/aws-samples/dbt-glue/issues/90)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
-## v1.3.0 
+## v0.3.0 
 
-- Updated dependencies to support dbt-core 1.3.0 and switched to mainline version numbering
+- Updated dependencies to support dbt-core 1.3.0
 
 ## v0.2.14 (unreleased)
 

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,8 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.2.15"
-dbt_min_version = "1.2.0"
-dbt_max_version = "1.3.2"
+package_version = "1.3.0"
+dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(
     name=package_name,
@@ -55,8 +54,8 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-core >={}, <={}".format(dbt_min_version, dbt_max_version),
-        "dbt-spark >={}, <={}".format(dbt_min_version, dbt_max_version),
+        "dbt-core~={}".format(dbt_version),
+        "dbt-spark~={}".format(dbt_version),
         "waiter",
         "boto3"
     ],

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.2.7"
-dbt_version = "1.2.0"
+package_version = "0.2.15"
+dbt_min_version = "1.2.0"
+dbt_max_version = "1.3.2"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(
     name=package_name,
@@ -54,8 +55,8 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-core~={}".format(dbt_version),
-        "dbt-spark~={}".format(dbt_version),
+        "dbt-core >={}, <={}".format(dbt_min_version, dbt_max_version),
+        "dbt-spark >={}, <={}".format(dbt_min_version, dbt_max_version),
         "waiter",
         "boto3"
     ],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "1.3.0"
+package_version = "0.3.0"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(


### PR DESCRIPTION
resolves #85 


### Description

This updates setup.py to support a min and max dbt-core/dbt-spark version allowing us to support version. 1.2.0 and 1.3.0 for a period.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
