### PR TITLE
Consider full_refresh config when using incremental model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
-## v0.3.0 
+## v0.3.1 (unreleased)
+- Include config `full_refresh` flag when materialization is incremental
 
+## v0.3.0
 - Updated dependencies to support dbt-core 1.3.0
 
-## v0.2.15 (unreleased)
-
-## v0.2.14 (unreleased)
+## v0.2.15
 - Force database parameter must be omitted or have the same value as schema  [Github Issue Link](https://github.com/aws-samples/dbt-glue/issues/93)
 
 ## v0.2.14

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -11,7 +11,8 @@
   {%- set partition_by = config.get('partition_by', none) -%}
   {%- set custom_location = config.get('custom_location', default='empty') -%}
 
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
+  {%- set full_refresh_config = config.get('full_refresh', default=False) -%}
+  {%- set full_refresh_mode = (flags.FULL_REFRESH == True or full_refresh_config == True) -%}
 
   {% set target_relation = this %}
   {% set existing_relation_type = adapter.get_table_type(target_relation)  %}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.3.0"
+package_version = "0.3.1"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(


### PR DESCRIPTION
resolves #99


### Description

dbt-core has a bug that doesn't consider the the full_refresh config in the `flags.FULL_REFRESH`. This PR introduce a small change that consider also the `full_refresh` config parameter.

To test this implementation, I used this this config
```
{{ config(
    materialized='incremental',
    file_format='parquet',
    incremental_strategy='insert_overwrite',
    partition_by=['report_date'],
    full_refresh = True
) }}
```
having that lead the the incremental do to a full refresh, therefore the table is dropped and recreated.

Benefits of this are:
- a consistent behaviour with the usage of the `is_incremental()` macro, that kicks in when the `full_refresh` flag is set to True.
- when adding new columns, we want to run a full_refresh mode, hence changing minimal configuration. The  `full_refresh` allow the usage of variables to be pass to the model, those are more flexible than using the --full-refresh flag, as we can change variables easily in the orchestration layer.


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
