### PR TITLE
Feature/iceberg table materializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
-## v0.4.0
+## v0.3.3
 - Add support for Iceberg table materializion, and iceberg_table_replace materializion
 
 ## v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
-## v0.3.0 
+## v0.4.0
+- Add support for Iceberg table materializion, and iceberg_table_replace materializion
 
+## v0.3.0
 - Updated dependencies to support dbt-core 1.3.0
 
 ## v0.2.15 (unreleased)

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import re
 import uuid
@@ -423,8 +424,6 @@ SqlWrapper2.execute("""select * from {model["schema"]}.{model["name"]} limit 1""
             except Exception as e:
                 logger.error(e)
 
-
-
     @available
     def delta_create_table(self, target_relation, request, primary_key, partition_key, custom_location):
         session, client, cursor = self.get_connection()
@@ -599,3 +598,30 @@ SqlWrapper2.execute("""SELECT * FROM {target_relation.schema}.{target_relation.n
             cursor.execute(code)
         except Exception as e:
             logger.error(e)
+
+    @available
+    def iceberg_expire_snapshots(self, catalog, table):
+        """
+        Helper function to call snapshot expiration.
+        The function check for the latest snapshot and it expire it.
+        """
+        session, client, cursor = self.get_connection()
+        logger.debug(f'expiring snapshots for table {str(table)}')
+
+        expire_sql = f"CALL {catalog}.system.expire_snapshots('{str(table)}', timestamp 'to_replace')"
+
+        code = f'''
+        custom_glue_code_for_dbt_adapter
+        history_df = spark.sql("select committed_at from {catalog}.{table}.snapshots order by committed_at desc")
+        last_commited_at = str(history_df.first().committed_at)
+        expire_sql_procedure = f"{expire_sql}".replace("to_replace", last_commited_at)
+        result_df = spark.sql(expire_sql_procedure)
+        SqlWrapper2.execute("""SELECT 1""")
+        '''
+        logger.debug(f"""expire procedure code:
+            {code}
+            """)
+        try:
+            cursor.execute(code)
+        except Exception as e:
+            logger.error('error when expiring iceberg snapshots' + e)

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -514,10 +514,14 @@ PARTITIONED BY ({part_list})
             logger.debug(e)
             pass
         try:
-            type = self.relation_type_map.get(response.get("Table", {}).get("TableType", "Table"))
+            _type = self.relation_type_map.get(response.get("Table", {}).get("TableType", "Table"))
+            _specific_type = response.get("Table", {}).get('Parameters', {}).get('table_type', '')
+
+            if _specific_type.lower() == 'iceberg':
+                _type = 'iceberg_table'
             logger.debug("table_name : " + relation.name)
-            logger.debug("table type : " + type)
-            return type
+            logger.debug("table type : " + _type)
+            return _type
         except Exception as e:
             return None
 

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -625,4 +625,4 @@ SqlWrapper2.execute("""SELECT * FROM {target_relation.schema}.{target_relation.n
         try:
             cursor.execute(code)
         except Exception as e:
-            logger.error('error when expiring iceberg snapshots' + e)
+            logger.error(e)

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -603,7 +603,8 @@ SqlWrapper2.execute("""SELECT * FROM {target_relation.schema}.{target_relation.n
     def iceberg_expire_snapshots(self, catalog, table):
         """
         Helper function to call snapshot expiration.
-        The function check for the latest snapshot and it expire it.
+        The function check for the latest snapshot and it expire all versions before it.
+        If the table has only one snapshot it is retained.
         """
         session, client, cursor = self.get_connection()
         logger.debug(f'expiring snapshots for table {str(table)}')

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -57,19 +57,19 @@
   {% if temporary -%}
     {{ create_temporary_view(relation, sql) }}
   {%- else -%}
-    {% if file_format == 'iceberg' -%}
+    {% if file_format == 'iceberg' %}
     {%- set default_catalog = 'iceberg_catalog' -%}
-    create table {{ default_catalog }}.{{ relation }}
-    {%- else -%}
-    create table {{ relation }}
-    {%- endif -%}
+    	create table {{ default_catalog }}.{{ relation }}
+    {% else %}
+    	create table {{ relation }}
+    {% endif %}
     {{ glue__file_format_clause() }}
-    {{ partition_cols(label="partitioned by") }}
-    {{ clustered_cols(label="clustered by") }}
-    {{ glue__location_clause(relation) }}
-    {{ comment_clause() }}
-    as
-      {{ sql }}
+	{{ partition_cols(label="partitioned by") }}
+	{{ clustered_cols(label="clustered by") }}
+	{{ glue__location_clause(relation) }}
+	{{ comment_clause() }}
+	as
+	{{ sql }}
   {%- endif %}
 {%- endmacro -%}
 

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -139,3 +139,8 @@
 {% macro spark__type_string() -%}
     STRING
 {%- endmacro %}
+
+{% macro iceberg_expire_snapshots(relation, timestamp, keep_versions) -%}
+    {%- set default_catalog = 'iceberg_catalog' -%}
+    {% set result = adapter.iceberg_expire_snapshots(default_catalog, relation, timestamp, keep_versions )  %}
+{%- endmacro %}

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -20,14 +20,14 @@
 {% macro glue__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
   {% set rel_type = adapter.get_table_type(relation)  %}
-  	{%- if rel_type is not none and rel_type != 'iceberg_table' %}
+    {%- if rel_type is not none and rel_type != 'iceberg_table' %}
         drop {{ rel_type }} if exists {{ relation }}
     {%- elif rel_type is not none and rel_type == 'iceberg_table' %}
     	{%- set default_catalog = 'iceberg_catalog' -%}
         drop table if exists {{ default_catalog }}.{{ relation }}
   	{%- else -%}
         drop table if exists {{ relation }}
-  	{%- endif %}
+    {%- endif %}
   {%- endcall %}
 {% endmacro %}
 

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -67,4 +67,3 @@
   {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}
-

--- a/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
+++ b/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
@@ -1,12 +1,21 @@
 {% materialization iceberg_table_replace, adapter='glue' -%}
   {%- set default_catalog = 'iceberg_catalog' -%}
   {%- set partition_by = config.get('partition_by', none) -%}
+  {%- set expire_snapshots = config.get('expire_snapshots', true) -%}
   {% set target_relation = this %}
   {% set build_sql = create_or_replace(default_catalog, target_relation) %}
+
+	{{ run_hooks(pre_hooks) }}
 
   {%- call statement('main') -%}
     {{ build_sql }}
   {%- endcall -%}
+
+  {%- if expire_snapshots == true -%}
+  	{%- set result = adapter.iceberg_expire_snapshots(default_catalog, target_relation) -%}
+  {%- endif -%}
+
+	{{ run_hooks(post_hooks) }}
 
 	{{ return({'relations': [target_relation]}) }}
 

--- a/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
+++ b/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
@@ -1,24 +1,23 @@
 {% materialization iceberg_table_replace, adapter='glue' -%}
-	{%- set default_catalog = 'iceberg_catalog' -%}
-	{%- set partition_by = config.get('partition_by', none) -%}
-	{% set target_relation = this %}
+  {%- set default_catalog = 'iceberg_catalog' -%}
+  {%- set partition_by = config.get('partition_by', none) -%}
+  {% set target_relation = this %}
+  {% set build_sql = create_or_replace(default_catalog, target_relation) %}
 
-	{% set build_sql = create_or_replace(default_catalog, target_relation) %}
+  {%- call statement('main') -%}
+    {{ build_sql }}
+  {%- endcall -%}
 
-	{%- call statement('main') -%}
-     {{ build_sql }}
-  	{%- endcall -%}
-
-  	{{ return({'relations': [target_relation]}) }}
+	{{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}
 
 {% macro create_or_replace(default_catalog, relation) %}
-    create or replace table {{ default_catalog }}.{{ relation }}
-    using ICEBERG
-	{{ partition_cols(label="partitioned by") }}
-	{{ glue__location_clause(relation) }}
-	{{ comment_clause() }}
-	as
-	{{ sql }}
+  create or replace table {{ default_catalog }}.{{ relation }}
+  using ICEBERG
+  {{ partition_cols(label="partitioned by") }}
+  {{ glue__location_clause(relation) }}
+  {{ comment_clause() }}
+  as
+  {{ sql }}
 {% endmacro %}

--- a/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
+++ b/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
@@ -1,0 +1,24 @@
+{% materialization iceberg_table_replace, adapter='glue' -%}
+	{%- set default_catalog = 'iceberg_catalog' -%}
+	{%- set partition_by = config.get('partition_by', none) -%}
+	{% set target_relation = this %}
+
+	{% set build_sql = create_or_replace(default_catalog, target_relation) %}
+
+	{%- call statement('main') -%}
+     {{ build_sql }}
+  	{%- endcall -%}
+
+  	{{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization %}
+
+{% macro create_or_replace(default_catalog, relation) %}
+    create or replace table {{ default_catalog }}.{{ relation }}
+    using ICEBERG
+	{{ partition_cols(label="partitioned by") }}
+	{{ glue__location_clause(relation) }}
+	{{ comment_clause() }}
+	as
+	{{ sql }}
+{% endmacro %}

--- a/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
+++ b/dbt/include/glue/macros/materializations/table/iceberg_table_replace.sql
@@ -1,9 +1,10 @@
 {% materialization iceberg_table_replace, adapter='glue' -%}
   {%- set default_catalog = 'iceberg_catalog' -%}
   {%- set partition_by = config.get('partition_by', none) -%}
-  {%- set expire_snapshots = config.get('expire_snapshots', true) -%}
-  {% set target_relation = this %}
-  {% set build_sql = create_or_replace(default_catalog, target_relation) %}
+  {%- set expire_snapshots = config.get('expire_snapshots', default=true) -%}
+  {%- set table_properties = config.get('table_properties', default={}) -%}
+  {%- set target_relation = this -%}
+  {%- set build_sql = create_or_replace(default_catalog, target_relation, table_properties) -%}
 
 	{{ run_hooks(pre_hooks) }}
 
@@ -21,9 +22,10 @@
 
 {%- endmaterialization %}
 
-{% macro create_or_replace(default_catalog, relation) %}
+{% macro create_or_replace(default_catalog, relation, table_properties) %}
   create or replace table {{ default_catalog }}.{{ relation }}
   using ICEBERG
+  {{ set_table_properties(table_properties) }}
   {{ partition_cols(label="partitioned by") }}
   {{ glue__location_clause(relation) }}
   {{ comment_clause() }}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.3.0"
+package_version = "0.3.1"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.3.1"
+package_version = "0.4.0"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.4.0"
+package_version = "0.3.3"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(


### PR DESCRIPTION
## Description
This PR is the first of many to add Iceberg as format supported by dbt-glue.
This PR cover 2 materializations:
* table: where the table is dropped and recreated in each run
* iceberg_table_replace: a specific materialization for iceberg to benefit of zero downtime, when using full table rebuild.


## Notes
* Due to some limitation of dbt-core, we cannot access the configs in the drop macro, therefore the catalog name is hardcoded in the adaptor.
* when working with ref, it's important to always use the notation `iceberg_catalog.{{ref('iceberg_example_2')}}` to let glue understand that is an iceberg_table
* I decided to bump the version to 0.4.0 as this introduce a big feature

## TODO
- [x] Add support for table properties in this PR

### Checklist
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Tests that were run

### Materialization table

#### Models

Model 1 without reference: 
```
{{ config(
    materialized='table',
    ffile_format='iceberg',
    partition_by=['status']
	)
}}

WITH data AS (
	SELECT 'A' AS user_id, 'active' AS status, 'pi' AS name
	UNION ALL
	SELECT 'B' AS user_id, 'active' AS status, 'sh' AS name
	UNION ALL
	SELECT 'C' AS user_id, 'inactive' AS status, 'zh' AS name
)

SELECT
	user_id,
	status,
	name,
	current_timestamp() AS inserted_at,
	'yet another column' AS new_column
FROM data
```
Model 2 with reference (note the iceberg_catalog prefix).
```
{{ config(
    materialized='table',
    file_format='iceberg'
    )
}}

SELECT
	*
FROM iceberg_catalog.{{ref('iceberg_example_1')}}
WHERE
	status = 'active'
```

### Materialisation: iceberg_table_replace

```
{{ config(
    materialized='iceberg_table_replace',
    partition_by=['status']
	)
}}

WITH data AS (
	SELECT 'A' AS user_id, 'active' AS status, 'pi' AS name
	UNION ALL
	SELECT 'B' AS user_id, 'active' AS status, 'sh' AS name
	UNION ALL
	SELECT 'C' AS user_id, 'inactive' AS status, 'zh' AS name
)

SELECT
	user_id,
	status,
	name,
	current_timestamp() AS inserted_at,
	'yet another column' AS new_column
FROM data
```
Multiple run of those lead to new snapshots/versions in the table. This is pretty awesome, as we have zero downtime.
The materialization support an optional argument call `expire_snapshots` that keep only the latest snapshot, to avoid to blow space. If for specific reasons, like auding it's necessary to keep the all history, we can add simply `expire_snapshots=False`


### Support for table properties

Table properties can be set using the `table_properties` field.
```
{{ config(
    materialized='table',
    partition_by=['status'],
    table_properties={
    	'write.target-file-size-bytes	': '536870912'
    }
)
}}
```

Full properties set can be found here: https://iceberg.apache.org/docs/latest/configuration/
