### PR TITLE
Fix inconstant iceberg default location due to final trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.3.4
 
 - Add method to create a default location for Iceberg without using final trailing slash.
-  The fix will make the tables readable from query engines like Trino.
+  The fix will make Iceberg tables readable from query engines like Trino.
 
 ## v0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
+## v0.3.4
+
+- Add method to create a default location for Iceberg without using final trailing slash.
+  The fix will make the tables readable from query engines like Trino.
+
 ## v0.3.3
 
 - Add support for Iceberg table materializion, and iceberg_table_replace materializion

--- a/README.md
+++ b/README.md
@@ -564,6 +564,15 @@ Full config example:
 ```
 A full reference to `table_properties` can be found [here](https://iceberg.apache.org/docs/latest/configuration/).
 
+### Notes
+
+#### Trailing slashes in custom location
+When using a custom_location in Iceberg, avoid to use final trailing slash.
+Adding a final trailing slash lead to an un-proper handling of the location, and issues when reading the data from
+query engines like Trino. 
+The issue should be fixed for Iceberg version > 0.13.
+Related Github issue can be find [here](https://github.com/apache/iceberg/issues/4582).
+
 ## Monitoring your Glue Interactive Session
 
 Monitoring is an important part of maintaining the reliability, availability,

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -1,5 +1,6 @@
 import datetime
 import io
+import os
 import re
 import uuid
 import boto3
@@ -215,6 +216,16 @@ class GlueAdapter(SQLAdapter):
     def get_location(self, relation: BaseRelation):
         session, client, cursor = self.get_connection()
         return f"LOCATION '{session.credentials.location}/{relation.schema}/{relation.name}/'"
+
+    @available
+    def get_iceberg_location(self, relation: BaseRelation):
+        """
+        Helper method to deal with issues due to trailing / in Iceberg location.
+        The method ensure that no final slash is in the location.
+        """
+        session, client, cursor = self.get_connection()
+        s3_path = os.path.join(session.credentials.location, relation.schema, relation.name)
+        return f"LOCATION '{s3_path}'"
 
     def drop_schema(self, relation: BaseRelation) -> None:
         session, client, cursor = self.get_connection()

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -7,7 +7,7 @@
     location '{{ custom_location }}'
   {%- else -%}
     {% if file_format == 'iceberg' or materialized == 'iceberg_table_replace' %}
-			{{ adapter.get_iceberg_location(relation) }}
+      {{ adapter.get_iceberg_location(relation) }}
     {%- else -%}
     	{{ adapter.get_location(relation) }}
     {%- endif %}

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -1,9 +1,16 @@
 {% macro glue__location_clause(relation) %}
   {%- set custom_location = config.get('custom_location', validator=validation.any[basestring]) -%}
+  {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
+  {%- set materialized = config.get('materialized') -%}
+
   {%- if custom_location is not none %}
     location '{{ custom_location }}'
   {%- else -%}
-    {{ adapter.get_location(relation) }}
+    {% if file_format == 'iceberg' or materialized == 'iceberg_table_replace' %}
+			{{ adapter.get_iceberg_location(relation) }}
+    {%- else -%}
+    	{{ adapter.get_location(relation) }}
+    {%- endif %}
   {%- endif %}
 {%- endmacro -%}
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.3.3"
+package_version = "0.3.4"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(


### PR DESCRIPTION
### Description
When working with Iceberg I noticed that the final / in the location of the table create weird extra / slash in the prefix of the objects in S3.

When using custom location of this type 's3://my_bucket/db/table' the issue doesn't persist. 
Therefore I decided to use this default behaviour creating a `get_iceberg_location` to return default location without final /. 
The final slash makes my iceberg tables unreadable from trino, somehow athena seems dealing with it, as the glue/spark.

See this related issue https://github.com/apache/iceberg/issues/4582.
Using version older then 0.13 fix the issue partially, as the metadata objects still suffer of the same problem (this must be addressed to the community developing Iceberg, I will reach out), for now that is the best fix to be able to use iceberg tables with other systems.


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
