### PR TITLE
Specify location for tmp table

### DIFF
--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -87,6 +87,7 @@
     DROP TABLE IF EXISTS {{ relation }}
     dbt_next_query
     create table {{ relation }}
+    {{ glue__location_clause(relation) }}
     as
       {{ sql }}
   {% endcall %}


### PR DESCRIPTION
### Description

Adds a location to temp table definitions to resolve errors in 0.3.4

For example:
```
14:31:21    Glue cursor returned `error` for statement None for code SqlWrapper2.execute('''
...
14:31:21        DROP TABLE IF EXISTS example_db.example_table_tmp
14:31:21        dbt_next_query
14:31:21        create table example_db.example_table_tmp
14:31:21        as
14:31:21          
14:31:21    
14:31:21    select
...
14:31:21      '''), IllegalArgumentException: Can not create a Path from an empty string
```

This error seems to occur because the full specification should be:
```
create table example_db.example_table_tmp
location 's3://some-s3-path'
as 
select
...
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
