### PR TITLE
Add error checking for HUDI incremental materializations

### DIFF
--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -8,6 +8,9 @@
   {%- set strategy = dbt_spark_validate_get_incremental_strategy(raw_strategy, file_format) -%}
 
   {%- set unique_key = config.get('unique_key', none) -%}
+  {% if unique_key is none and file_format == 'hudi' %}
+    {{ exceptions.raise_compiler_error("unique_key model configuration is required for HUDI incremental materializations.") }}
+  {% endif %}
   {%- set partition_by = config.get('partition_by', none) -%}
   {%- set custom_location = config.get('custom_location', default='empty') -%}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def dbt_profile_target():
         'query-comment': 'test-glue-adapter',
         'role_arn': os.getenv('DBT_ROLE_ARN'),
         'user': os.getenv('DBT_ROLE_ARN'),
-        'region': 'eu-west-1',
+        'region': os.getenv("AWS_REGION", 'eu-west-1'),
         'workers': 2,
         'worker_type': 'G.1X',
         'schema': 'dbt_functional_test_01',


### PR DESCRIPTION
resolves #119

### Description

Add error checking in `incremental.sql` to make the `unique_key` config option required for HUDI incremental models.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
