### PR TITLE
Increase retry and backoff settings for Boto

### DIFF
--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dbt import exceptions as dbterrors
 import boto3
+from botocore.config import Config
 from waiter import wait
 from dbt.adapters.glue.gluedbapi.cursor import GlueCursor, GlueDictCursor
 from dbt.adapters.glue.credentials import GlueCredentials
@@ -136,8 +137,14 @@ class GlueConnection:
 
     @property
     def client(self):
+        config = Config(
+            retries={
+                'max_attempts': 10,
+                'mode': 'adaptive'
+            }
+        )
         if not self._client:
-            self._client = boto3.client("glue", region_name=self.credentials.region)
+            self._client = boto3.client("glue", region_name=self.credentials.region, config=config)
         return self._client
 
     def cancel_statement(self, statement_id):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
 package_name = "dbt-glue"
-package_version = "0.3.6"
+package_version = "0.3.7"
 dbt_version = "1.3.0"
 description = """dbt (data build tool) adapter for Aws Glue"""
 setup(


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #121 
-->

### Description

Updates the boto connection settings to use the new adaptive backoff settings and also increases the default retry limit.
When used with threads this has decreased my docs generation time by over 40 mins

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
