### PR TITLE
Adding iceberg support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## dbt-glue 1.0.0 (Release TBD)
 
+## v1.3.91
+- add details on Iceberg documentation (provide details on commit locking, catalog alias. Provide least privilege IAM Permission for DynamoDB Commit Locking. Correct typos)
+- add customizable DynamoDB table name for Iceberg Commit Locking.
+- Refactor unused --conf parameter for Iceberg file format (warehouse_path)
+
 ## v1.3.9
 - implementation of Iceberg append, merge, and insert_overwrite operation and refacto of the existing create and create or replace implementation.
 - add method to create dbt snapshots from Iceberg tables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.3.91
 - add details on Iceberg documentation (provide details on commit locking, catalog alias. Provide least privilege IAM Permission for DynamoDB Commit Locking. Correct typos)
 - add customizable DynamoDB table name for Iceberg Commit Locking.
-- Refactor unused --conf parameter for Iceberg file format (warehouse_path)
+- Refactoring of unused --conf parameter for Iceberg file format (warehouse_path)
 
 ## v1.3.9
 - implementation of Iceberg append, merge, and insert_overwrite operation and refacto of the existing create and create or replace implementation.

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -27,6 +27,7 @@ class GlueCredentials(Credentials):
     seed_format: Optional[str] = "parquet"
     seed_mode: Optional[str] = "overwrite"
     default_arguments: Optional[str] = None
+    iceberg_glue_commit_lock_table: Optional[str] = "myGlueLockTable"
 
     @property
     def type(self):
@@ -77,5 +78,6 @@ class GlueCredentials(Credentials):
             'tags',
             'seed_format',
             'seed_mode',
-            'default_arguments'
+            'default_arguments', 
+            'iceberg_glue_commit_lock_table'
         ]

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -191,7 +191,7 @@ class GlueAdapter(SQLAdapter):
             from pyspark.sql import SparkSession
             from pyspark.sql.functions import *
             warehouse_path = f"{session.credentials.location}/{relation.schema}"
-            dynamodb_table = 'myGlueLockTable'
+            dynamodb_table = f"{session.credentials.iceberg_glue_commit_lock_table}"
             spark = SparkSession.builder \
                 .config("spark.sql.warehouse.dir", warehouse_path) \
                 .config(f"spark.sql.catalog.glue_catalog", "org.apache.iceberg.spark.SparkCatalog") \
@@ -747,7 +747,7 @@ custom_glue_code_for_dbt_adapter
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import *
 warehouse_path = f"{session.credentials.location}/{target_relation.schema}"
-dynamodb_table = 'myGlueLockTable'
+dynamodb_table = f"{session.credentials.iceberg_glue_commit_lock_table}"
 spark = SparkSession.builder \
     .config("spark.sql.warehouse.dir", warehouse_path) \
     .config(f"spark.sql.catalog.glue_catalog", "org.apache.iceberg.spark.SparkCatalog") \


### PR DESCRIPTION
resolves #


### Description
In response to comments on previously merged PR (#130) this PR : 
- adds details on Iceberg documentation (provide details on commit locking, catalog alias. provide least privilege IAM permissions for DynamoDB Commit Locking. Correct typos)
- adds customizable DynamoDB table name for Iceberg Commit Locking.
- performs refactoring of unused --conf parameter for Iceberg file format (warehouse_path)

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
