### PR TITLE
always use "append" mode for hudi "merge" strategy

### DIFF
--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -630,8 +630,9 @@ PARTITIONED BY ({part_list})
                 'hoodie.bloom.index.update.partition.path': 'true',
             }
 
+        write_mode = 'Append'
         if isTableExists:
-            write_mode = 'Overwrite'
+            # write_mode = 'Overwrite'
             write_operation_config = {
                 'hoodie.upsert.shuffle.parallelism': 20,
                 'hoodie.datasource.write.operation': 'upsert',
@@ -639,12 +640,12 @@ PARTITIONED BY ({part_list})
                 'hoodie.cleaner.commits.retained': 10,
             }
         else :
-            write_mode = 'Append'
+            # write_mode = 'Append'
             write_operation_config = {
                 'hoodie.bulkinsert.shuffle.parallelism': 20,
                 'hoodie.datasource.write.operation': 'bulk_insert',
             }
-
+        
         combined_config = {**base_config, **partition_config, **write_operation_config, **hudi_config}
 
         code = f'''


### PR DESCRIPTION
resolves #144 

### Description

Always use "append" mode for HUDI merge instead of "overwrite"

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
