### PR TITLE
add execute_pyspark capability for registering python/pyspark UDFs

### DIFF
--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -847,3 +847,23 @@ SqlWrapper2.execute("""SELECT * FROM glue_catalog.{target_relation.schema}.{targ
             raise DatabaseException(msg="GlueIcebergExpireSnapshotsFailed") from e
         except Exception as e:
             logger.error(e)
+
+    @available
+    def execute_pyspark(self, codeblock):
+        session, client, cursor = self.get_connection()
+
+        code = f"""
+custom_glue_code_for_dbt_adapter
+{codeblock}
+        """
+
+        logger.debug(f"""pyspark code :
+        {code}
+        """)
+
+        try:
+            cursor.execute(code)
+        except DatabaseException as e:
+            raise DatabaseException(msg="GlueExecutePySparkFailed") from e
+        except Exception as e:
+            logger.error(e)


### PR DESCRIPTION
This is useful to register python UDFs in the underlying pyspark to be used elsewhere in the sql models! These macros can be attached to the dbt lifecycle hooks - https://docs.getdbt.com/docs/build/hooks-operations#getting-started-with-hooks-and-operations

Example registration of UDF (hex to integer conversion): 
```
{% macro register_udf_hex_to_int() %}

    {% if execute %}
        
        {% set code = """
from pyspark.sql.functions import udf
from pyspark.sql.types import IntegerType

@udf(IntegerType())
def hex_to_int(x):
    return int(x, 16)

spark.udf.register('hex_to_int', hex_to_int)
        """ %}

        {% do adapter.execute_pyspark(code) %}

    {% endif %}

{% endmacro %}
```