### PR TITLE
run pre_hooks before create tmp table

### DIFF
--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -33,6 +33,8 @@
     set spark.sql.autoBroadcastJoinThreshold=-1
   {% endcall %}
 
+  {{ run_hooks(pre_hooks) }}
+
   {% if file_format == 'hudi' %}
         {%- set hudi_options = config.get('hudi_options', default={}) -%}
         {{ adapter.hudi_merge_table(target_relation, sql, unique_key, partition_by, custom_location, hudi_options) }}
@@ -70,8 +72,6 @@
         {% set build_sql = dbt_glue_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key) %}
       {% endif %}
   {% endif %}
-	
-  {{ run_hooks(pre_hooks) }}
 
   {%- call statement('main') -%}
      {{ build_sql }}


### PR DESCRIPTION
resolves #

Resolves https://github.com/aws-samples/dbt-glue/issues/181

### Description

Move the step of running pre_hooks before creating temp table in incremental strategy.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
