### PR TITLE
use session to build client - to be threadsafe

### DIFF
--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -140,7 +140,8 @@ class GlueConnection:
             }
         )
         if not self._client:
-            self._client = boto3.client("glue", region_name=self.credentials.region, config=config)
+            session = boto3.session.Session()
+            self._client = session.client("glue", region_name=self.credentials.region, config=config)
         return self._client
 
     def cancel_statement(self, statement_id):

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -7,6 +7,7 @@ from dbt.adapters.glue.gluedbapi.cursor import GlueCursor, GlueDictCursor
 from dbt.adapters.glue.credentials import GlueCredentials
 from dbt.adapters.glue.gluedbapi.commons import GlueStatement
 import time
+import threading
 import uuid
 from dbt.events import AdapterLogger
 
@@ -23,6 +24,7 @@ class GlueSessionState:
 
 @dataclass
 class GlueConnection:
+    _boto3_client_lock = threading.Lock()
 
     def __init__(self, credentials: GlueCredentials, session_id: str = None):
         self.credentials = credentials
@@ -140,8 +142,10 @@ class GlueConnection:
             }
         )
         if not self._client:
-            session = boto3.session.Session()
-            self._client = session.client("glue", region_name=self.credentials.region, config=config)
+            # refernce on why lock is required - https://stackoverflow.com/a/61943955/6034432
+            with self._boto3_client_lock:
+                session = boto3.session.Session()
+                self._client = session.client("glue", region_name=self.credentials.region, config=config)
         return self._client
 
     def cancel_statement(self, statement_id):


### PR DESCRIPTION
resolves #

```KeyError: 'credential_provider'```

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->
Building boto3 client with DEFAULT session is breaking when using threads - [Reference used](https://github.com/boto/boto3/issues/1592#issuecomment-1379880226)

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
