### PR TITLE
enable models to substitute sql with pyspark variables

### DIFF
--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -34,10 +34,11 @@
   {% endcall %}
 
   {{ run_hooks(pre_hooks) }}
+  {%- set substitute_variables = config.get('substitute_variables', default=[]) -%}
 
   {% if file_format == 'hudi' %}
         {%- set hudi_options = config.get('hudi_options', default={}) -%}
-        {{ adapter.hudi_merge_table(target_relation, sql, unique_key, partition_by, custom_location, hudi_options) }}
+        {{ adapter.hudi_merge_table(target_relation, sql, unique_key, partition_by, custom_location, hudi_options, substitute_variables) }}
         {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
   {% elif file_format == 'iceberg' %}
         {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->
This will help to split the pyspark execution scripts using pre-hooks to prepare for any runtime variables to be read from datasources
Example usage:
```
# macros/set_max_hoodie_commit_time.sql
{% macro set_max_hoodie_commit_time(schema, table_name) %}

    {% if execute %}
        
        {% set code = """
max_hoodie_commit_time_df = spark.sql('select max(_hoodie_commit_time) as max from " ~ schema ~ "." ~ table_name ~ "')
collect = max_hoodie_commit_time_df.collect()

# this is the variable which is being substituted
max_hoodie_commit_time = collect[0]['max']   
        """ %}

        {% do adapter.execute_pyspark(code) %}

    {% endif %}

{% endmacro %}
```

```
# models/model_a.sql
{{ 
        config(
            pre_hook="{{ set_max_hoodie_commit_time(this.schema, this.identifier) }}",
            substitute_variables=["max_hoodie_commit_time"],
        )
}}

select * from table
where _hoodie_commit_time >= '<SUBSTITUTE_VARIABLE_0>'

```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
