### PR TITLE
re-use the glue-session to run multiple dbt run commands

### DIFF
--- a/dbt/adapters/glue/connections.py
+++ b/dbt/adapters/glue/connections.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 import agate
-from typing import Any, List, Dict
+from typing import Any, List, Dict,Optional
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterResponse
 from dbt.exceptions import (
@@ -80,14 +80,16 @@ class GlueConnectionManager(SQLConnectionManager):
 
     @classmethod
     def get_result_from_cursor(cls, cursor: GlueCursor) -> agate.Table:
+        limit= 10
         data: List[Any] = []
         column_names: List[str] = []
-
         if cursor.description is not None:
-            column_names = cursor.columns
-            rows = cursor.fetchall()
+            column_names = [col[0] for col in cursor.description()]
+            if limit:
+                rows = cursor.fetchmany(limit)
+            else:
+                rows = cursor.fetchall()
             data = cls.process_results(column_names, rows)
-
         return dbt.clients.agate_helper.table_from_data_flat(
             data,
             column_names

--- a/dbt/adapters/glue/connections.py
+++ b/dbt/adapters/glue/connections.py
@@ -79,8 +79,7 @@ class GlueConnectionManager(SQLConnectionManager):
         )
 
     @classmethod
-    def get_result_from_cursor(cls, cursor: GlueCursor) -> agate.Table:
-        limit= 10
+    def get_result_from_cursor(cls, cursor: GlueCursor, limit:Optional[int]) -> agate.Table:
         data: List[Any] = []
         column_names: List[str] = []
         if cursor.description is not None:

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -28,6 +28,8 @@ class GlueCredentials(Credentials):
     default_arguments: Optional[str] = None
     iceberg_glue_commit_lock_table: Optional[str] = "myGlueLockTable"
     use_interactive_session_role_for_api_calls: bool = False
+    glue_session_id:  Optional[str] = None
+    glue_session_reuse: Optional[bool] = False
 
     @property
     def type(self):
@@ -79,5 +81,8 @@ class GlueCredentials(Credentials):
             'seed_mode',
             'default_arguments', 
             'iceberg_glue_commit_lock_table', 
-            'lf_tags'
+            'lf_tags',
+            'glue_session_id',
+            'glue_session_reuse'
+
         ]

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -18,17 +18,17 @@ class GlueSessionState:
     READY = "READY"
     FAILED = "FAILED"
     PROVISIONING = "PROVISIONING"
-    RUNNING = "RUNNING"
-    CLOSED = "CLOSED"
+    TIMEOUT = "TIMEOUT"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
 
 
 @dataclass
 class GlueConnection:
     _boto3_client_lock = threading.Lock()
-
     def __init__(self, credentials: GlueCredentials, session_id: str = None):
         self.credentials = credentials
-        self._session_id = session_id
+        self._session_id = credentials.glue_session_id
         self._client = None
         self._session = None
         self._state = None
@@ -43,8 +43,17 @@ class GlueConnection:
                 "Session": {"Id": self._session_id}
             }
             logger.debug("Existing session with status : " + self.state)
-            if self.state == GlueSessionState.CLOSED:
-                self._session = self._start_session()
+            for elapsed in wait(1):
+                if self.state in [GlueSessionState.FAILED, GlueSessionState.STOPPED, GlueSessionState.TIMEOUT]:
+                    self.delete_session(session_id=self._session_id)
+                    self._session = self._start_session()
+                    return self.session_id
+                elif self.state in [GlueSessionState.PROVISIONING, GlueSessionState.STOPPING]:
+                        logger.info(
+                            f"[elapsed {elapsed}s - waiting glue_session for {self.session_id} in {self.state}")
+                elif self.state == GlueSessionState.READY:
+                    self._set_session_ready()
+                    return self.session_id
 
         return self.session_id
 
@@ -90,7 +99,8 @@ class GlueConnection:
         session_uuidStr = str(session_uuid)
         session_prefix = self.credentials.role_arn.partition('/')[2] or self.credentials.role_arn
         id = f"{session_prefix}-dbt-glue-{session_uuidStr}"
-
+        if self.session_id:
+            id = self.session_id
         try:
             self._session = self.client.create_session(
                 Id=id,
@@ -159,8 +169,18 @@ class GlueConnection:
         logger.debug("GlueConnection cancel called")
         response = self.client.get_statements(SessionId=self.session_id)
         for statement in response["Statements"]:
-            if statement["State"] in GlueSessionState.RUNNING:
+            if statement["State"] in GlueSessionState.READY:
                 self.cancel_statement(statement_id=statement["Id"])
+
+    def delete_session(self, session_id):
+        try:
+            self.client.delete_session(
+                Id=session_id,
+                RequestOrigin='dbt-glue-'+self.credentials.role_arn.partition('/')[2] or self.credentials.role_arn
+            )
+        except Exception as e:
+            logger.debug(f"delete session {session_id} error")
+            raise e
 
     def close(self):
         logger.debug("NotImplemented: close")
@@ -170,12 +190,13 @@ class GlueConnection:
         logger.debug("NotImplemented: rollback")
 
     def cursor(self, as_dict=False) -> GlueCursor:
-        logger.debug("GlueConnection cursor called")
+        # logger.debug(f"GlueConnection cursor called, current session: {self.session_id}, state: {self.state}")
         if self.state == GlueSessionState.READY:
             self._init_session()
             return GlueDictCursor(connection=self) if as_dict else GlueCursor(connection=self)
         else:
             for elapsed in wait(1):
+                logger.debug(f"[elapsed {elapsed}s - cursor waiting glue session state to ready for {self.session_id} in {self.state} state")
                 if self.state == GlueSessionState.READY:
                     self._init_session()
                     return GlueDictCursor(connection=self) if as_dict else GlueCursor(connection=self)
@@ -187,12 +208,13 @@ class GlueConnection:
         logger.debug("GlueConnection close_session called")
         if not self._session:
             return
-
+        if self.credentials.glue_session_reuse:
+            logger.info(f"reuse session, do not stop_session for {self.session_id} in {self.state} state")
+            return
         for elapsed in wait(1):
-            if self.state not in [GlueSessionState.PROVISIONING, GlueSessionState.READY, GlueSessionState.RUNNING]:
+            if self.state not in [GlueSessionState.PROVISIONING, GlueSessionState.READY , GlueSessionState.STOPPING]:
                 return
-            
-            logger.debug(f"[elapsed {elapsed}s - calling stop_session for {self.session_id} in {self.state} state")
+            logger.info(f"[elapsed {elapsed}s - calling stop_session for {self.session_id} in {self.state} state")
             try:
                 self.client.stop_session(Id=self.session_id)
             except Exception as e:
@@ -207,12 +229,27 @@ class GlueConnection:
         if self._state in [GlueSessionState.FAILED]:
             return self._state
         try:
+            if not self.session_id:
+                self._session = {
+                    "Session": {"Id": self._session_id}
+                }
             response = self.client.get_session(Id=self.session_id)
             session = response.get("Session", {})
             self._state = session.get("Status")
-        except:
-            self._state = GlueSessionState.CLOSED
+        except Exception as e:
+            logger.debug(f"get session state error session_id: {self._session_id}, {self.session_id}")
+            logger.debug(e)
+            self._state = GlueSessionState.STOPPED
         return self._state
+
+    def _set_session_ready(self):
+        try:
+            response = self.client.get_session(Id=self._session_id)
+            self._session = response
+            self._session_create_time = response.get("Session", {}).get("CreatedOn")
+        except Exception as e:
+            logger.debug(f"set session ready error")
+            raise e
 
     def _string_to_dict(self, value_to_convert):
         value_in_dictionary = {}

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -49,7 +49,7 @@ class GlueConnection:
                     self._session = self._start_session()
                     return self.session_id
                 elif self.state in [GlueSessionState.PROVISIONING, GlueSessionState.STOPPING]:
-                        logger.info(
+                        logger.debug(
                             f"[elapsed {elapsed}s - waiting glue_session for {self.session_id} in {self.state}")
                 elif self.state == GlueSessionState.READY:
                     self._set_session_ready()
@@ -209,12 +209,12 @@ class GlueConnection:
         if not self._session:
             return
         if self.credentials.glue_session_reuse:
-            logger.info(f"reuse session, do not stop_session for {self.session_id} in {self.state} state")
+            logger.debug(f"reuse session, do not stop_session for {self.session_id} in {self.state} state")
             return
         for elapsed in wait(1):
             if self.state not in [GlueSessionState.PROVISIONING, GlueSessionState.READY , GlueSessionState.STOPPING]:
                 return
-            logger.info(f"[elapsed {elapsed}s - calling stop_session for {self.session_id} in {self.state} state")
+            logger.debug(f"[elapsed {elapsed}s - calling stop_session for {self.session_id} in {self.state} state")
             try:
                 self.client.stop_session(Id=self.session_id)
             except Exception as e:

--- a/dbt/adapters/glue/gluedbapi/cursor.py
+++ b/dbt/adapters/glue/gluedbapi/cursor.py
@@ -5,6 +5,7 @@ from dbt.contracts.connection import AdapterResponse
 from dbt import exceptions as dbterrors
 from dbt.adapters.glue.gluedbapi.commons import GlueStatement
 from dbt.events import AdapterLogger
+from typing import Optional
 
 logger = AdapterLogger("Glue")
 
@@ -162,6 +163,22 @@ class GlueCursor:
 
             return records
 
+    def fetchmany(self, limit: Optional[int]):
+        logger.debug("GlueCursor fetchall called")
+        if self.closed:
+            raise Exception("CursorClosed")
+
+        if self.response:
+            records = []
+            i = 0
+            for item in self.response.get("results", []):
+                record = []
+                for column in self.columns:
+                    record.append(item.get("data", {}).get(column, None))
+                if i < limit:
+                    records.append(record)
+                    i = i+1
+            return records
     def fetchone(self):
         logger.debug("GlueCursor fetchone called")
         if self.closed:


### PR DESCRIPTION
resolves #200 #210

### Description
1. re-use the glue-session to run multiple dbt run commands, add two config options. 

|Option | Description | Mandatory|
-- | -- | --
|glue_session_id|set a glue session id you need to use|no|
|glue_session_reuse| If set to true, the glue session will not be closed for re-use. If set to false, the session will be closed|no|

2. glue session state do not have   RUNNING  and CLOSED ,but have STOPPED ,STOPPING,TIMEOUT. Fixed these sates.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
