### PR TITLE
fix the boto3 version to use lakeformation tags

### DIFF
--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -157,7 +157,7 @@ class GlueConnection:
 
     def cancel(self):
         logger.debug("GlueConnection cancel called")
-        response = self.client.get_statements(SessionId=self.session_id)
+        response = self.client.list_statements(SessionId=self.session_id)
         for statement in response["Statements"]:
             if statement["State"] in GlueSessionState.RUNNING:
                 self.cancel_statement(statement_id=statement["Id"])

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "dbt-core~={}".format(dbt_version),
         "dbt-spark~={}".format(dbt_spark_version),
         "waiter",
-        "boto3"
+        "boto3 >= 1.28.16"
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
- fix requirement to use boto3 version for LakeFormation Tags
- Fix cancel statement on glue interactive sessions

resolves #203

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #203 
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
