### PR TITLE
Adding database level Lake Formation tag management 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.6.1
+- adding support for database AWS Lake Formation tag management
+
 ## v1.6.0
 - adding support for AWS Lake Formation tag management
 - adding support for AWS Lake Formation data filtering and row, column, cell level security

--- a/README.md
+++ b/README.md
@@ -833,15 +833,12 @@ use the `schema` config and `generate_schema_name` macro _only_.
 For more information, check the dbt documentation about [custom schemas](https://docs.getdbt.com/docs/build/custom-schemas).
 
 ## AWS Lakeformation integration
-The adapter supports AWS Lakeformation tags management enabling you to associate existing tags defined out of dbt-glue to database objects built by dbt-glue (table, view, snapshot, incremental models, seeds).
+The adapter supports AWS Lake Formation tags management enabling you to associate existing tags defined out of dbt-glue to database objects built by dbt-glue (database, table, view, snapshot, incremental models, seeds).
 
 - You can enable or disable lf-tags management via config, at model and dbt-project level (disabled by default)
 - If enabled, lf-tags will be updated on every dbt run. There are table level lf-tags configs and column-level lf-tags configs. 
-- You can specify that you want to drop existing table lf-tags or column lf-tags by setting the drop_existing config field to True (False by default, meaning existing tags are kept)
+- You can specify that you want to drop existing database, table column Lake Formation tags by setting the drop_existing config field to True (False by default, meaning existing tags are kept)
 - Please note that if the tag you want to associate with the table does not exist, the dbt-glue execution will throw an error
-- dbt-glue does not manage database-level lf-tags, meaning :
-  - you can't associate database lf-tags within dbt-glue
-  - if the table inherits from a database lf-tags defined outside of dbt, dbt-glue does not drop this tag.
 
 The adapter also supports AWS Lakeformation data cell filtering. 
 - You can enable or disable data-cell filtering via config, at model and dbt-project level (disabled by default)
@@ -898,9 +895,13 @@ This way of defining your Lakeformation rules is appropriate if you want to hand
     lf_tags_config={
           'enabled': true,
           'drop_existing' : False,
-          'tags': 
+          'tags_database': 
           {
-            'name_of_my_lf_tag': 'value_of_my_tag'          
+            'name_of_my_db_tag': 'value_of_my_db_tag'          
+            }, 
+          'tags_table': 
+          {
+            'name_of_my_table_tag': 'value_of_my_table_tag'          
             }, 
           'tags_columns': {
             'name_of_my_lf_tag': {
@@ -947,16 +948,20 @@ This is especially useful for seeds, for which you can't define configuration in
 seeds:
   +lf_tags_config:
     enabled: true
-    tags: 
-      name_of_my_tag: 'value_of_my_tag'     
+    tags_table: 
+      name_of_my_table_tag: 'value_of_my_table_tag'  
+    tags_database: 
+      name_of_my_database_tag: 'value_of_my_database_tag'
 models:
   +lf_tags_config:
     enabled: true
     drop_existing: True
-    tags: 
-      name_of_my_tag: 'value_of_my_tag'
+    tags_database: 
+      name_of_my_database_tag: 'value_of_my_database_tag'
+    tags_table: 
+      name_of_my_table_tag: 'value_of_my_table_tag'
 ```
-  
+
 ## Tests
 
 To perform a functional test:

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -909,7 +909,10 @@ SqlWrapper2.execute("""SELECT * FROM glue_catalog.{target_relation.schema}.{targ
             conn = self.connections.get_thread_connection()
             client = conn.handle
             lf = boto3.client("lakeformation", region_name=client.credentials.region)
-            manager = LfTagsManager(lf, relation, config)
+            sts = boto3.client("sts")
+            identity = sts.get_caller_identity()
+            account = identity.get("Account")
+            manager = LfTagsManager(lf, account, relation, config)
             manager.process_lf_tags()
             return
         logger.debug(f"Lakeformation is disabled for {relation}")

--- a/dbt/adapters/glue/lakeformation.py
+++ b/dbt/adapters/glue/lakeformation.py
@@ -36,7 +36,7 @@ class LfTagsManager:
             existing_lf_tags_database = self.lf_client.get_resource_lf_tags(
             Resource=db_resource)
             if self.drop_existing:
-                self._remove_lf_tags_database(existing_lf_tags_database)
+                self._remove_lf_tags_database(db_resource, existing_lf_tags_database)
             self._apply_lf_tags_database(db_resource)
         table_resource = {
             "Table": {"DatabaseName": self.database, "Name": self.table}}

--- a/dbt/include/glue/macros/materializations/snapshot.sql
+++ b/dbt/include/glue/macros/materializations/snapshot.sql
@@ -143,7 +143,8 @@
   {%- set config = model['config'] -%}
 
   {%- set target_table = model.get('alias', model.get('name')) -%}
-
+  {%- set lf_tags_config = config.get('lf_tags_config') -%}
+  {%- set lf_grants = config.get('lf_grants') -%}
   {%- set strategy_name = config.get('strategy') -%}
   {%- set unique_key = config.get('unique_key') %}
   {%- set file_format = config.get('file_format', 'parquet') -%}
@@ -261,7 +262,15 @@
   {% call statement('main') %}
       {{ final_sql }}
   {% endcall %}
+  
+  {% if lf_tags_config is not none %}
+  {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+  {% endif %}
 
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
+  {% endif %}
+  
   {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode) %}
   {% do apply_grants(target_relation, grant_config, should_revoke) %}
 


### PR DESCRIPTION
This PR adds Lake Formation tag management at database level.
It allows tags to be added to the database in which dbt models are built. By specifying *tags_database* in the configuration, you can associate existing Lake Formation tags with the database, and by setting drop_existing to True, you can replace existing tags.  
To avoid any ambiguity in parameter naming, we've also changed the name of the parameter used to configure table-level tags, replacing "tags" with "tags_table".

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
