### PR TITLE
Feature/glue session per model

### DIFF
--- a/dbt/adapters/glue/connections.py
+++ b/dbt/adapters/glue/connections.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import agate
 from typing import Any, List, Dict
+from dbt.adapters.glue.credentials import GlueCredentials
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterResponse
 from dbt.exceptions import (
@@ -10,6 +11,7 @@ from dbt.exceptions import (
 import dbt
 from dbt.adapters.glue.gluedbapi import GlueConnection, GlueCursor
 from dbt.events import AdapterLogger
+from dbt.events.contextvars import get_node_info
 
 logger = AdapterLogger("Glue")
 
@@ -23,7 +25,7 @@ class ReturnCode:
 
 class GlueConnectionManager(SQLConnectionManager):
     TYPE = "glue"
-    GLUE_CONNECTIONS_BY_THREAD: Dict[str, GlueConnection] = {}
+    GLUE_CONNECTIONS_BY_KEY: Dict[str, GlueConnection] = {}
 
 
     @classmethod
@@ -32,14 +34,30 @@ class GlueConnectionManager(SQLConnectionManager):
             logger.debug("Connection is already open, skipping open.")
             return connection
 
-        credentials = connection.credentials
+        credentials: GlueCredentials = connection.credentials
         try:
-            key = cls.get_thread_identifier()
-            if not cls.GLUE_CONNECTIONS_BY_THREAD.get(key):
+            connection_args = {
+                "credentials": credentials
+            }
+            
+            if credentials.enable_session_per_model:
+                key = get_node_info().get("unique_id", "no-node")
+                connection_args['session_id_suffix'] = key
+
+                session_config_overrides = {}
+                for session_config in credentials._connection_keys():
+                    if get_node_info().get("meta", {}).get(session_config):
+                        session_config_overrides[session_config] = get_node_info().get("meta", {}).get(session_config)
+                connection_args['session_config_overrides'] = session_config_overrides
+
+            else:
+                key = cls.get_thread_identifier()
+
+            if not cls.GLUE_CONNECTIONS_BY_KEY.get(key):
                 logger.debug(f"opening a new glue connection for thread : {key}")
-                cls.GLUE_CONNECTIONS_BY_THREAD[key]: GlueConnection = GlueConnection(credentials=credentials)
+                cls.GLUE_CONNECTIONS_BY_KEY[key]: GlueConnection = GlueConnection(**connection_args)
             connection.state = GlueSessionState.OPEN
-            connection.handle = cls.GLUE_CONNECTIONS_BY_THREAD[key]
+            connection.handle = cls.GLUE_CONNECTIONS_BY_KEY[key]
             return connection
         except Exception as e:
             logger.error(
@@ -107,7 +125,7 @@ class GlueConnectionManager(SQLConnectionManager):
 
     def cleanup_all(self):
         logger.debug("cleanup called")
-        for connection in self.GLUE_CONNECTIONS_BY_THREAD.values():
+        for connection in self.GLUE_CONNECTIONS_BY_KEY.values():
             try:
                 connection.close_session()
             except Exception as e:

--- a/dbt/adapters/glue/connections.py
+++ b/dbt/adapters/glue/connections.py
@@ -38,7 +38,6 @@ class GlueConnectionManager(SQLConnectionManager):
             if not cls.GLUE_CONNECTIONS_BY_THREAD.get(key):
                 logger.debug(f"opening a new glue connection for thread : {key}")
                 cls.GLUE_CONNECTIONS_BY_THREAD[key]: GlueConnection = GlueConnection(credentials=credentials)
-                cls.GLUE_CONNECTIONS_BY_THREAD[key].connect()
             connection.state = GlueSessionState.OPEN
             connection.handle = cls.GLUE_CONNECTIONS_BY_THREAD[key]
             return connection

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -28,7 +28,7 @@ class GlueCredentials(Credentials):
     default_arguments: Optional[str] = None
     iceberg_glue_commit_lock_table: Optional[str] = "myGlueLockTable"
     use_interactive_session_role_for_api_calls: bool = False
-    enable_session_per_model = False
+    enable_session_per_model: bool = False
 
     @property
     def type(self):

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -28,6 +28,7 @@ class GlueCredentials(Credentials):
     default_arguments: Optional[str] = None
     iceberg_glue_commit_lock_table: Optional[str] = "myGlueLockTable"
     use_interactive_session_role_for_api_calls: bool = False
+    enable_session_per_model = False
 
     @property
     def type(self):
@@ -78,5 +79,6 @@ class GlueCredentials(Credentials):
             'seed_format',
             'seed_mode',
             'default_arguments', 
-            'iceberg_glue_commit_lock_table'
+            'iceberg_glue_commit_lock_table',
+            'enable_session_per_model'
         ]

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -38,7 +38,7 @@ class GlueConnection:
             self._start_session()
         else:
             self._session = {
-                "Session": {"Id": self._session_id}
+                "Session": {"Id": self._session_id or self.session_id}
             }
             logger.debug("Existing session with status : " + self.state)
             if self.state == GlueSessionState.CLOSED:

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -33,7 +33,7 @@ class GlueConnection:
 
     def _connect(self):
         logger.debug("GlueConnection connect called")
-        if not self.session_id and self._session_id:
+        if self._session_id or self.session_id:
             logger.debug("No session present, starting one")
             self._start_session()
         else:

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -33,7 +33,7 @@ class GlueConnection:
 
     def _connect(self):
         logger.debug("GlueConnection connect called")
-        if self._session_id or self.session_id:
+        if not (self._session_id or self.session_id):
             logger.debug("No session present, starting one")
             self._start_session()
         else:

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -31,9 +31,9 @@ class GlueConnection:
         self._session = None
         self._state = None
 
-    def connect(self):
+    def _connect(self):
         logger.debug("GlueConnection connect called")
-        if not self._session_id:
+        if not self.session_id and self._session_id:
             logger.debug("No session present, starting one")
             self._start_session()
         else:
@@ -166,6 +166,7 @@ class GlueConnection:
 
     def cursor(self, as_dict=False) -> GlueCursor:
         logger.debug("GlueConnection cursor called")
+        self._connect()
         if self.state == GlueSessionState.READY:
             self._init_session()
             return GlueDictCursor(connection=self) if as_dict else GlueCursor(connection=self)


### PR DESCRIPTION
resolves https://getdbt.slack.com/archives/C02R4HSMBAT/p1693226615486969

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->
- tried to bring an optional feature to enable individual glue sessions (with possible overrides of worker configurations) per model
- can be enabled using the `enable_session_per_model: true` flag in the profiles.yml
- can override the session configurations by putting the corresponding config under `meta` config for a model
```
{{
    config(
        meta={
            "workers": 3,
            "idle_timeout": 10,
            "worker_type": "G.2X"
        }
    )
}}
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
