### PR TITLE
Refactor session creation, fix full refresh flag and columns listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,6 @@ venv/
 .pypirc
 
 dbt_venv/
+.venv/
 
 .pytest_cache/

--- a/dbt/adapters/glue/gluedbapi/commons.py
+++ b/dbt/adapters/glue/gluedbapi/commons.py
@@ -34,6 +34,12 @@ class GlueStatement:
         for elasped in wait(1):
             response = self._get_statement()
             state = response.get("Statement", {}).get("State", GlueStatement.WAITING)
-            if state in [GlueStatement.AVAILABLE, GlueStatement.ERROR,GlueStatement.CANCELLING, GlueStatement.WAITING, GlueStatement.TIMEOUT]:
+
+            if state == GlueStatement.WAITING:
+                # if in waiting state, continue to wait
+                # TODO this could potentially wait forever?
+                continue
+
+            if state in [GlueStatement.AVAILABLE, GlueStatement.ERROR,GlueStatement.CANCELLING, GlueStatement.TIMEOUT]:
                 break
         return response

--- a/dbt/adapters/glue/gluedbapi/cursor.py
+++ b/dbt/adapters/glue/gluedbapi/cursor.py
@@ -216,7 +216,7 @@ class GlueCursor:
         if self.statement:
             r = self.statement._get_statement()
             return AdapterResponse(
-                _message=f'r["State"]',
+                _message=r.get('Statement', {}).get("State", ""),
                 code=self.sql,
                 **r
             )

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -1,10 +1,10 @@
 {% materialization incremental, adapter='glue' -%}
-  
+
   {#-- Validate early so we don't run SQL if the file_format + strategy combo is invalid --#}
   {%- set raw_file_format = config.get('file_format', default='parquet') -%}
   {%- set raw_strategy = config.get('incremental_strategy', default='insert_overwrite') -%}
-  
-  {% if raw_file_format == 'iceberg' %} 
+
+  {% if raw_file_format == 'iceberg' %}
     {%- set file_format = 'iceberg' -%}
     {%- set strategy = raw_strategy -%}
   {% else %}
@@ -22,7 +22,7 @@
 
 
   {%- set full_refresh_config = config.get('full_refresh', default=False) -%}
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == 'True' or full_refresh_config == 'True') -%}
+  {%- set full_refresh_mode = (flags.FULL_REFRESH or full_refresh_config) -%}
 
   {% set target_relation = this %}
   {% set existing_relation_type = adapter.get_table_type(target_relation)  %}
@@ -88,7 +88,7 @@
   {% if lf_grants is not none %}
     {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
   {% endif %}
-  
+
   {% if is_incremental == 'True' %}
     {{ glue__drop_relation(tmp_relation) }}
     {% if file_format == 'delta' %}


### PR DESCRIPTION
resolves #254 

### Description

This PR refactors session creation/handling of stale sessions. In case of a session reuse, parallel models trying to create a session are synchronized via a lock. Waiter logic is contained in a single place. In addition, `enable_session_per_model` is considered together with `glue_session_reuse` and `glue_session_id` configurations.

Replaces condition check for full refresh flag using string equality with booleans.

Updates getting columns from a relation, by ignoring empty responses as well as the fixed text `Not partitioned` (returned in case relation is not partitioned).

Also, currently GlueStatement response is returned immediately if state is WAITING. This is changed to wait until state has moved out of WAITING.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
