### PR TITLE
ensure GHA's tox runs integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = unit, flake8, integration-spark-thrift
+envlist = unit, integration
 
 [testenv:{unit}]
 allowlist_externals =
@@ -16,7 +16,7 @@ deps =
 [testenv:{integration}]
 allowlist_externals =
     /bin/bash
-commands = /bin/bash -c '{envpython} -m pytest -v {posargs}'
+commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/functional/adapter/'
 passenv =
     DBT_*
     PYTEST_ADDOPTS


### PR DESCRIPTION
resolves #240

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

currently, only bespoke unit tests are running, not the adapter integration tests provided by dbt Labs. This PR should fix that so that [`tests/functional/adapter/test_basic.py`](https://github.com/aws-samples/dbt-glue/blob/main/tests/functional/adapter/test_basic.py) will now run.

Note that there are MANY more tests provided that are still not set up to run (see [dbt-core's `tests/adapter/dbt/tests/adapter/` dir](https://github.com/dbt-labs/dbt-core/tree/e547c0ec6444b11c677c54506e09f903bcce29a0/tests/adapter/dbt/tests/adapter) for a more comprehensive list

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
