### PR TITLE
[doc] Remove unnecessary extra_py_files for Delta Lake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next version
+- Remove unnecessary parameter for Delta Lake from readme
+
 ## v1.7.0
 - add compatibility with dbt 1.6
 - fixed tests 

--- a/README.md
+++ b/README.md
@@ -479,8 +479,6 @@ You can also use Delta Lake to be able to use merge feature on tables.
 - To add the following config in your Interactive Session Config (in your profile):  `conf: "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog`
 
 **Athena:** Athena is not compatible by default with delta tables, but you can configure the adapter to create Athena tables on top of your delta table. To do so, you need to configure the two following options in your profile:
-- For Delta Lake 2.1.0 supported natively in Glue 4.0: `extra_py_files: "/opt/aws_glue_connectors/selected/datalake/delta-core_2.12-2.1.0.jar"`
-- For Delta Lake 1.0.0 supported natively in Glue 3.0: `extra_py_files: "/opt/aws_glue_connectors/selected/datalake/delta-core_2.12-1.0.0.jar"`
 - `delta_athena_prefix: "the_prefix_of_your_choice"`
 - If your table is partitioned, then the add of new partition is not automatic, you need to perform an `MSCK REPAIR TABLE your_delta_table` after each new partition adding
 
@@ -502,7 +500,6 @@ test_project:
       location: "s3://aws-dbt-glue-datalake-1234567890-eu-west-1/"
       datalake_formats: delta
       conf: "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
-      extra_py_files: "/opt/aws_glue_connectors/selected/datalake/delta-core_2.12-2.1.0.jar"
       delta_athena_prefix: "delta"
 ```
 


### PR DESCRIPTION
### Description

In the past, users had to configure `extra_py_files` to run Delta Python API. However, now it's no longer required because AWS Glue resolved the limitation.

### Testing

Existing integration tests already cover this. There's no such configuration in the configuration for the integration tests https://github.com/aws-samples/dbt-glue/blob/main/tests/conftest.py

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
