### PR TITLE
[minor][doc] Fix Iceberg config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,8 @@ group by 1
       - the latest connector for iceberg in AWS marketplace uses Ver 0.14.0 for Glue 3.0, and Ver 1.2.1 for Glue 4.0 where Kryo serialization fails when writing iceberg, use "org.apache.spark.serializer.JavaSerializer" for spark.serializer instead, more info [here](https://github.com/apache/iceberg/pull/546) 
     - For Athena version 2: The adapter is compatible with the Iceberg Connector from AWS Marketplace with Glue 3.0 as Fulfillment option and 0.12.0-2 (Feb 14, 2022) as Software version)
 - For Glue 4.0, to add the following configurations in dbt-profile:  
-```--conf spark.sql.catalog.glue_catalog=org.apache.iceberg.spark.SparkCatalog  
+```
+    --conf spark.sql.catalog.glue_catalog=org.apache.iceberg.spark.SparkCatalog
     --conf spark.sql.catalog.glue_catalog.warehouse=s3://<PATH_TO_YOUR_WAREHOUSE>
     --conf spark.sql.catalog.glue_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog 
     --conf spark.sql.catalog.glue_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO 


### PR DESCRIPTION
### Description

`--conf spark.sql.catalog.glue_catalog=org.apache.iceberg.spark.SparkCatalog` is not shown in the readme. Just a formatting issue.

### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
