### PR TITLE
Fix wrong role create db#285

### DIFF
--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -29,7 +29,7 @@ class GlueCredentials(Credentials):
     seed_mode: Optional[str] = "overwrite"
     default_arguments: Optional[str] = None
     iceberg_glue_commit_lock_table: Optional[str] = "myGlueLockTable"
-    use_interactive_session_role_for_api_calls: bool = False
+    use_interactive_session_role_for_api_calls: bool = True
     lf_tags: Optional[str] = None
     glue_session_id: Optional[str] = None
     glue_session_reuse: Optional[bool] = False

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -329,7 +329,8 @@ class GlueAdapter(SQLAdapter):
                 logger.error(e)
         else:
             logger.debug("No schema to delete")
-
+            
+    @available
     def create_schema(self, relation: BaseRelation):
         session, client = self.get_connection()
         lf = boto3.client("lakeformation", region_name=session.credentials.region)

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -78,21 +78,18 @@ class GlueAdapter(SQLAdapter):
     def get_connection(self):
         connection: GlueConnectionManager = self.connections.get_thread_connection()
         glueSession: GlueConnection = connection.handle
-        if glueSession.credentials.role_arn is not None:
-            if glueSession.credentials.use_interactive_session_role_for_api_calls is True:
-                sts_client = boto3.client('sts')
-                assumed_role_object = sts_client.assume_role(
-                    RoleArn=glueSession.credentials.role_arn,
-                    RoleSessionName="dbt"
-                )
-                credentials = assumed_role_object['Credentials']
-                session = boto3.Session(
-                    aws_access_key_id=credentials['AccessKeyId'],
-                    aws_secret_access_key=credentials['SecretAccessKey'],
-                    aws_session_token=credentials['SessionToken']
-                )
 
-        client = boto3.client("glue", region_name=glueSession.credentials.region)
+        sts_client = boto3.client('sts')
+        assumed_role_object = sts_client.assume_role(
+            RoleArn=glueSession.credentials.role_arn,
+            RoleSessionName="dbt"
+        )
+        credentials = assumed_role_object['Credentials']
+
+        client = boto3.client("glue", region_name=glueSession.credentials.region,                   
+                            aws_access_key_id=credentials['AccessKeyId'],
+                            aws_secret_access_key=credentials['SecretAccessKey'],
+                            aws_session_token=credentials['SessionToken'])
 
         return glueSession, client
 

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -326,7 +326,7 @@ class GlueAdapter(SQLAdapter):
                 logger.error(e)
         else:
             logger.debug("No schema to delete")
-            
+
     def create_schema(self, relation: BaseRelation):
         session, client = self.get_connection()
         lf = boto3.client("lakeformation", region_name=session.credentials.region)

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -78,20 +78,23 @@ class GlueAdapter(SQLAdapter):
     def get_connection(self):
         connection: GlueConnectionManager = self.connections.get_thread_connection()
         glueSession: GlueConnection = connection.handle
+        if glueSession.credentials.role_arn is not None:
+            if glueSession.credentials.use_interactive_session_role_for_api_calls is True:
+                sts_client = boto3.client('sts')
+                assumed_role_object = sts_client.assume_role(
+                    RoleArn=glueSession.credentials.role_arn,
+                    RoleSessionName="dbt"
+                )
+                credentials = assumed_role_object['Credentials']
+                glue_client = boto3.client("glue", region_name=glueSession.credentials.region,
+                                    aws_access_key_id=credentials['AccessKeyId'],
+                                    aws_secret_access_key=credentials['SecretAccessKey'],
+                                    aws_session_token=credentials['SessionToken'])
+                return glueSession, glue_client
 
-        sts_client = boto3.client('sts')
-        assumed_role_object = sts_client.assume_role(
-            RoleArn=glueSession.credentials.role_arn,
-            RoleSessionName="dbt"
-        )
-        credentials = assumed_role_object['Credentials']
+        glue_client = boto3.client("glue", region_name=glueSession.credentials.region)
 
-        client = boto3.client("glue", region_name=glueSession.credentials.region,                   
-                            aws_access_key_id=credentials['AccessKeyId'],
-                            aws_secret_access_key=credentials['SecretAccessKey'],
-                            aws_session_token=credentials['SessionToken'])
-
-        return glueSession, client
+        return glueSession, glue_client
 
     def list_schemas(self, database: str) -> List[str]:
         session, client = self.get_connection()

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -327,7 +327,6 @@ class GlueAdapter(SQLAdapter):
         else:
             logger.debug("No schema to delete")
             
-    @available
     def create_schema(self, relation: BaseRelation):
         session, client = self.get_connection()
         lf = boto3.client("lakeformation", region_name=session.credentials.region)

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -58,6 +58,10 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro glue__create_schema(relation) -%}
+  {{ adapter.create_schema(relation.database, relation.schema) }}
+{% endmacro %}
+
 {% macro glue__create_table_as(temporary, relation, sql) -%}
   {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
   {%- set table_properties = config.get('table_properties', default={}) -%}

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -58,10 +58,6 @@
   {%- endif %}
 {%- endmacro -%}
 
-{% macro glue__create_schema(relation) -%}
-  {{ adapter.create_schema(relation.database, relation.schema) }}
-{% endmacro %}
-
 {% macro glue__create_table_as(temporary, relation, sql) -%}
   {%- set file_format = config.get('file_format', validator=validation.any[basestring]) -%}
   {%- set table_properties = config.get('table_properties', default={}) -%}


### PR DESCRIPTION
resolves #285 

### Description

The CreateDabase operation is performed with the caller role. We want it to be performed by the glue session role_arn provided in profiles.yml.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
