### PR TITLE
Fix/choose role for api calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.venv*
 env*/
 dbt_env/
 build/

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -86,15 +86,15 @@ class GlueAdapter(SQLAdapter):
                     RoleSessionName="dbt"
                 )
                 credentials = assumed_role_object['Credentials']
-                session = boto3.Session(
-                    aws_access_key_id=credentials['AccessKeyId'],
-                    aws_secret_access_key=credentials['SecretAccessKey'],
-                    aws_session_token=credentials['SessionToken']
-                )
+                glue_client = boto3.client("glue", region_name=glueSession.credentials.region,
+                                    aws_access_key_id=credentials['AccessKeyId'],
+                                    aws_secret_access_key=credentials['SecretAccessKey'],
+                                    aws_session_token=credentials['SessionToken'])
+                return glueSession, glue_client
 
-        client = boto3.client("glue", region_name=glueSession.credentials.region)
+        glue_client = boto3.client("glue", region_name=glueSession.credentials.region)
 
-        return glueSession, client
+        return glueSession, glue_client
 
     def list_schemas(self, database: str) -> List[str]:
         session, client = self.get_connection()


### PR DESCRIPTION
resolves #285 

### Description

The CreateDabase operation is performed with the caller role. We want it to be performed by the glue session role_arn provided in profiles.yml.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
