### PR TITLE
Re-submit #286 to fix credential handling for use_interactive_session_role_for_api_calls

### DIFF
--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -29,7 +29,7 @@ class GlueCredentials(Credentials):
     seed_mode: Optional[str] = "overwrite"
     default_arguments: Optional[str] = None
     iceberg_glue_commit_lock_table: Optional[str] = "myGlueLockTable"
-    use_interactive_session_role_for_api_calls: bool = False
+    use_interactive_session_role_for_api_calls: Optional[bool] = False
     lf_tags: Optional[str] = None
     glue_session_id: Optional[str] = None
     glue_session_reuse: Optional[bool] = False


### PR DESCRIPTION
In # 319, We needed to revert multiple PRs including #286.
This PR is to re-submit PR #286 to fix credential handling for use_interactive_session_role_for_api_calls.

### Description

The CreateDabase operation is performed with the caller role. We want it to be performed by the glue session role_arn provided in profiles.yml.

Important note: There is a difference from #286. This PR does not change default value for `use_interactive_session_role_for_api_calls parameter`.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.