### PR TITLE
Fix unit test failure caused by moto 5 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## next version 
+- Fix unit test failure caused by moto 5 upgrade
 
 ## v1.7.2 
 - Fix the issue that removes double quote unexpectedly

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional
 import unittest
 from unittest import mock
 from botocore.client import BaseClient
-from moto import mock_glue
+from moto import mock_aws
 
 from dbt.config import RuntimeConfig
 
@@ -67,7 +67,7 @@ class TestGlueAdapter(unittest.TestCase):
             self.assertIsInstance(glueSession.client, BaseClient)
 
 
-    @mock_glue
+    @mock_aws
     def test_get_table_type(self):
         config = self._get_config()
         adapter = GlueAdapter(config)


### PR DESCRIPTION
### Description

moto version is upgraded to 5.x via #334 but it broke unit tests. This PR is to fix the broken unit tests.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.