### PR TITLE
Fix _create_session_config isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next version
 - Fix unit test failure caused by moto 5 upgrade
 - Fix pagination bug when listing glue databases and tables
+- Fix _create_session_config isolation to prevent overrides between sessions
 
 ## v1.7.2
 - Fix the issue that removes double quote unexpectedly

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -29,8 +29,6 @@ class GlueConnection:
     _boto3_client_lock = threading.Lock()
     _connect_lock = threading.Lock()
 
-    _create_session_config = {}
-
     def __init__(self, credentials: GlueCredentials, session_id_suffix: str = None, session_config_overrides = {}):
         self.credentials = credentials
         self._session_id_suffix = session_id_suffix
@@ -40,6 +38,7 @@ class GlueConnection:
         self._session_waiter = None
         self._session = None
         self._state = None
+        self._create_session_config = {}
 
         for key in self.credentials._connection_keys():
             self._create_session_config[key] = self._session_config_overrides.get(key) or getattr(self.credentials, key)


### PR DESCRIPTION
This PR addresses the issue related to sharing _create_session_config class attribute among Glue sessions. The fix prevents from overriding this attribute and enhances isolation.

Relates to https://github.com/aws-samples/dbt-glue/pull/234

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.