### PR TITLE
fix: pass in session timeout config to waiter vs delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next version
 - Fix unit test failure caused by moto 5 upgrade
 - Fix pagination bug when listing glue databases and tables
+- Fix Glue session state change waits until session timeout expires
 
 ## v1.7.2
 - Fix the issue that removes double quote unexpectedly

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -266,7 +266,7 @@ class GlueConnection:
             with self._boto3_client_lock:
                 session = boto3.session.Session()
                 self._client = session.client("glue", region_name=self.credentials.region, config=config)
-                self._session_waiter = get_session_waiter(client=self._client, delay=self.credentials.session_provisioning_timeout_in_seconds)
+                self._session_waiter = get_session_waiter(client=self._client, timeout=self.credentials.session_provisioning_timeout_in_seconds)
         return self._client
 
     def cancel_statement(self, statement_id):


### PR DESCRIPTION
resolves #351 

### Description

Pass in `session_provisioning_timeout_in_seconds` as `timeout` instead of `delay` to `get_session_waiter()`

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.