### PR TITLE
Fix tmp table location for the default file_format when custom_location is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix unit test failure caused by moto 5 upgrade
 - Fix pagination bug when listing glue databases and tables
 - Fix _create_session_config isolation to prevent overrides between sessions
+- Fix tmp table location for the default file_format
 
 ## v1.7.2
 - Fix the issue that removes double quote unexpectedly

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -91,7 +91,7 @@
     DROP TABLE IF EXISTS {{ relation }}
     dbt_next_query
     create table {{ relation }}
-    {{ glue__location_clause(relation) }}
+    {{ adapter.get_location(relation) }}
     as
       {{ sql }}
   {% endcall %}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -14,7 +14,8 @@ from dbt.tests.adapter.basic.test_singular_tests_ephemeral import BaseSingularTe
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
 from dbt.tests.util import (check_relations_equal, check_result_nodes_by_name,
-                            get_manifest, relation_from_name, run_dbt, get_s3_location)
+                            get_manifest, relation_from_name, run_dbt)
+from tests.util import get_s3_location
 
 
 # override schema_base_yml to set missing database

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -139,6 +139,7 @@ class TestIncrementalGlue(BaseIncremental):
     @pytest.fixture(scope="class")
     def models(self):
         model_incremental = """
+        {{ config(materialized="incremental") }}
            select * from {{ source('raw', 'seed') }}
            """.strip()
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -14,7 +14,7 @@ from dbt.tests.adapter.basic.test_singular_tests_ephemeral import BaseSingularTe
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
 from dbt.tests.util import (check_relations_equal, check_result_nodes_by_name,
-                            get_manifest, relation_from_name, run_dbt)
+                            get_manifest, relation_from_name, run_dbt, get_s3_location)
 
 
 # override schema_base_yml to set missing database
@@ -186,6 +186,19 @@ class TestIncrementalGlue(BaseIncremental):
         assert len(catalog.sources) == 1
 
     pass
+
+
+class TestIncrementalGlueWithCustomLocation(TestIncrementalGlue):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        default_location=get_s3_location()
+        custom_location = f"{default_location}/custom/incremental"
+        return {
+            "name": "incremental",
+            "models": {
+                "+custom_location": custom_location
+            }
+        }
 
 
 class TestGenericTestsGlue(BaseGenericTests):

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from dbt.tests.adapter.basic.files import (base_ephemeral_sql, base_table_sql,
                                            base_view_sql, ephemeral_table_sql,
-                                           ephemeral_view_sql)
+                                           ephemeral_view_sql,incremental_sql)
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
@@ -138,12 +138,8 @@ class TestSingularTestsEphemeralGlue(BaseSingularTestsEphemeral):
 class TestIncrementalGlue(BaseIncremental):
     @pytest.fixture(scope="class")
     def models(self):
-        model_incremental = """
-        {{ config(materialized="incremental") }}
-           select * from {{ source('raw', 'seed') }}
-           """.strip()
 
-        return {"incremental.sql": model_incremental, "schema.yml": schema_base_yml}
+        return {"incremental.sql": incremental_sql, "schema.yml": schema_base_yml}
 
     # test_incremental with refresh table
     def test_incremental(self, project):


### PR DESCRIPTION
resolves #360 


### Description

This PR addresses the fix for a bug related to the usage of custom_location for tmp table creation for the default table format in incremental materialization. It was decided to use the location set up in the profile instead of writing to the same location where the original table resides. 

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.