### PR TITLE
Iceberg/Delta CREATE OR REPLACE instead of DROP then CREATE

### DIFF
--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -638,7 +638,7 @@ SqlWrapper2.execute("""select * from {model["schema"]}.{model["name"]} limit 1""
             location = custom_location
 
         create_table_query = f"""
-CREATE TABLE {table_name}
+CREATE OR REPLACE TABLE {table_name}
 USING delta
 LOCATION '{location}'
         """
@@ -943,7 +943,7 @@ outputDf = inputDf.drop("dbt_unique_key").withColumn("update_iceberg_ts",current
         # Use standard table instead of temp view to workaround https://github.com/apache/iceberg/issues/7766
         if session.credentials.glue_version == "4.0":
             head_code += f'''outputDf.createOrReplaceTempView("tmp_tmp_{target_relation.name}")
-spark.sql("CREATE TABLE tmp_{target_relation.name} LOCATION '{session.credentials.location}/{target_relation.schema}/tmp_{target_relation.name}' AS SELECT * FROM tmp_tmp_{target_relation.name}")
+spark.sql("CREATE OR REPLACE TABLE tmp_{target_relation.name} LOCATION '{session.credentials.location}/{target_relation.schema}/tmp_{target_relation.name}' AS SELECT * FROM tmp_tmp_{target_relation.name}")
 '''
         else:
             head_code += f'outputDf.createOrReplaceTempView("tmp_{target_relation.name}")'

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -54,6 +54,7 @@
             {% set build_sql = create_table_as(False, target_relation, sql) %}
         {% endif %}
       {% elif existing_relation_type == 'view' or should_full_refresh() %}
+        {{ drop_relation(target_relation) }}
         {% if file_format == 'delta' %}
             {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location) }}
             {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 " %}

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -54,7 +54,6 @@
             {% set build_sql = create_table_as(False, target_relation, sql) %}
         {% endif %}
       {% elif existing_relation_type == 'view' or should_full_refresh() %}
-        {{ drop_relation(target_relation) }}
         {% if file_format == 'delta' %}
             {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location) }}
             {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 " %}


### PR DESCRIPTION
### Description

The iceberg/delta incremental materialization DROP and then CREATE the table. We could use CREATE OR REPLACE to avoid downtime

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.