### PR TITLE
Adding minimal write option when creating table with Delta format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## New versio
+## New version
 - Fix session provisioning timeout and delay handling
+- Add write options for Delta format
 
 ## v1.8.1
 - Fix typo in README.md

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -627,7 +627,7 @@ SqlWrapper2.execute("""select * from {model["schema"]}.{model["name"]} limit 1""
             self._update_additional_location(target_relation, location)
 
     @available
-    def delta_create_table(self, target_relation, request, primary_key, partition_key, custom_location):
+    def delta_create_table(self, target_relation, request, primary_key, partition_key, custom_location, delta_create_table_write_options=None):
         session, client = self.get_connection()
         logger.debug(request)
 
@@ -636,6 +636,11 @@ SqlWrapper2.execute("""select * from {model["schema"]}.{model["name"]} limit 1""
             location = f"{session.credentials.location}/{target_relation.schema}/{target_relation.name}"
         else:
             location = custom_location
+        
+        options_string = ""
+        if delta_create_table_write_options:
+            for key, value in delta_create_table_write_options.items():
+                options_string += f'.option("{key}", "{value}")'
 
         create_table_query = f"""
 CREATE TABLE {table_name}
@@ -647,7 +652,7 @@ LOCATION '{location}'
 custom_glue_code_for_dbt_adapter
 spark.sql("""
 {request}
-""").write.format("delta").mode("overwrite")'''
+""").write.format("delta").mode("overwrite"){options_string}'''
 
         write_data_footer = f'''.save("{location}")
 SqlWrapper2.execute("""select 1""")

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -19,6 +19,7 @@
   {%- set custom_location = config.get('custom_location', default='empty') -%}
   {%- set expire_snapshots = config.get('iceberg_expire_snapshots', 'True') -%}
   {%- set table_properties = config.get('table_properties', default='empty') -%}
+  {%- set delta_create_table_write_options = config.get('write_options', default={}) -%}
 
   {% set target_relation = this %}
   {% set existing_relation_type = adapter.get_table_type(target_relation)  %}
@@ -45,7 +46,7 @@
       {% endif %}
       {% if existing_relation_type is none %}
         {% if file_format == 'delta' %}
-            {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location) }}
+            {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location, delta_create_table_write_options) }}
             {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 " %}
         {% elif file_format == 'iceberg' %}
             {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}
@@ -56,7 +57,7 @@
       {% elif existing_relation_type == 'view' or should_full_refresh() %}
         {{ drop_relation(target_relation) }}
         {% if file_format == 'delta' %}
-            {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location) }}
+            {{ adapter.delta_create_table(target_relation, sql, unique_key, partition_by, custom_location, delta_create_table_write_options) }}
             {% set build_sql = "select * from " + target_relation.schema + "." + target_relation.identifier + " limit 1 " %}
         {% elif file_format == 'iceberg' %}
             {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}


### PR DESCRIPTION
resolves part of #415 

### Description
Add write option for creating table with file format Delta when using incremental strategy. For example, it allows --full-refresh when changing schema by adding a config : _delta_create_table_write_options = {"mergeSchema": "true"}_ to your model.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.

Credits : Nicolas Fourmann initially found this solution ! 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

FYI : I am not sure wether this change needs testing, if it does, I would be interested in understanding how to! 

## Test that were run locally
Simple model with minimal incremental merge strategy : 
```sql
{{
    config(
        materialized='incremental',
        incremental_strategy='merge',
        unique_key=['id'],
        file_format='delta',
    )
}}

with incoming_data as (
    select 1 as id
    union all
    select 2 as id
)

select * from incoming_data
```
’’’
No problem at first run but when adding a column and running : 
```bash
dbt run -s test_change_schema --full-refresh
```

Got an error from the glue adapter : 
```bash
08:23:55  Glue adapter: Glue returned `error` for statement None for code 

spark.sql("""


with incoming_data as (
    select 1 as id, 'a' as new_col
    union all
    select 2 as id, 'a' as new_col
)

select * from incoming_data
""").write.format("delta").mode("overwrite").save("s3://xxx/xxx/test_change_schema")
SqlWrapper2.execute("""select 1""")
, AnalysisException: A schema mismatch detected when writing to the Delta table (Table ID: xxx).
To enable schema migration using DataFrameWriter or DataStreamWriter, please set:
'.option("mergeSchema", "true")'.
For other operations, set the session configuration
spark.databricks.delta.schema.autoMerge.enabled to "true". See the documentation
specific to the operation for details.

Table schema:
root
-- id: integer (nullable = true)


Data schema:
root
-- id: integer (nullable = true)
-- new_col: string (nullable = true)

         
To overwrite your schema or change partitioning, please set:
'.option("overwriteSchema", "true")'.

Note that the schema can't be overwritten when using
'replaceWhere'.
```

Now adding the config and the model looks like : 
```sql
{{
    config(
        materialized='incremental',
        incremental_strategy='merge',
        unique_key=['id'],
        write_options = {"mergeSchema": "true"},
        file_format='delta',
    )
}}

with incoming_data as (
    select 1 as id, 'a' as new_col
    union all
    select 2 as id, 'a' as new_col
)

select * from incoming_data
````

And the same command passes gracefully and my table has its schema updated
