### PR TITLE
Strip unwanted partition columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## New versio
+## New version
 - Fix session provisioning timeout and delay handling
+- Fix get_columns_in_relation function to stop returning additional partition columns
 
 ## v1.8.1
 - Fix typo in README.md

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -265,6 +265,10 @@ class GlueAdapter(SQLAdapter):
         columns = [x for x in columns
                    if x.name not in self.HUDI_METADATA_COLUMNS]
 
+        # strip partition columns.
+        columns = [x for x in columns
+                   if not re.match(r'^Part \d+$', x.name)]
+
         logger.debug("columns after strip:")
         logger.debug(columns)
 


### PR DESCRIPTION
resolves #421 

### Description
Modify the function [get_columns_in_relation](https://github.com/aws-samples/dbt-glue/blob/726ae4c79a88a75c2e600ab54151998997707bc4/dbt/adapters/glue/impl.py#L206) so it does not return unwanted partitions related stuff like "Part 0", "Part 1", ... For more information on this behavior see [421](https://github.com/aws-samples/dbt-glue/issues/421)

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.

FYI : There are currently a "fake" tests associated with this function. I can update it to add one but I need information on how to mock a _BaseRelation_ object. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.