### PR TITLE
Changed GlueColumn base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## New versio
+## New version
 - Fix session provisioning timeout and delay handling
+- Change GlueColumn parent from base Column to SparkColumn
 
 ## v1.8.1
 - Fix typo in README.md

--- a/dbt/adapters/glue/column.py
+++ b/dbt/adapters/glue/column.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import ClassVar, Dict
 
-from dbt.adapters.base.column import Column
+from dbt.adapters.spark.column import SparkColumn
 
 
 @dataclass
-class GlueColumn(Column):
+class GlueColumn(SparkColumn):
     # Overwriting dafult string types to support glue
     # TODO: Convert to supported glue types as needed
     # Please ref: https://github.com/dbt-athena/dbt-athena/blob/main/dbt/adapters/athena/column.py

--- a/tests/unit/test_column.py
+++ b/tests/unit/test_column.py
@@ -1,0 +1,9 @@
+import unittest
+
+from dbt.adapters.glue.column import GlueColumn
+
+
+class TestGlueColumn(unittest.TestCase):
+    def test_column_quote(self):
+        test_column = GlueColumn("col_name", "INT")
+        self.assertEqual(test_column.quoted, "`col_name`")


### PR DESCRIPTION
resolves #423 

### Description
I changed the parent class of GlueColumn from Column (from dbt base) to SparkColumn

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.