### PR TITLE
Fix unraised DbtDatabaseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add on_schema_change possibility
 - Fix table materialization for Delta models
 - Change GlueColumn parent from base Column to SparkColumn
+- Fix unraised DbtDatabaseError
 
 ## v1.8.1
 - Fix typo in README.md

--- a/dbt/adapters/glue/gluedbapi/cursor.py
+++ b/dbt/adapters/glue/gluedbapi/cursor.py
@@ -3,6 +3,7 @@ import textwrap
 import json
 from dbt.adapters.contracts.connection import AdapterResponse
 from dbt import exceptions as dbterrors
+from dbt_common.exceptions import DbtDatabaseError
 from dbt.adapters.glue.gluedbapi.commons import GlueStatement
 from dbt.adapters.glue.util import get_pandas_dataframe_from_result_file
 from dbt.adapters.events.logging import AdapterLogger
@@ -128,7 +129,7 @@ class GlueCursor:
                     logger.error(error_message)
                 else:
                     logger.debug(error_message)
-                    raise dbterrors.DbtDatabaseError(msg=error_message)
+                    raise DbtDatabaseError(msg=error_message)
 
             self.result = self.response
             if self.connection.use_arrow:
@@ -143,11 +144,11 @@ class GlueCursor:
             output = response.get("Statement", {}).get("Output", {})
             error_message = f"Glue cursor returned `{output.get('Status')}` for statement {self.statement_id} for code {self.code}, {output.get('ErrorName')}: {output.get('ErrorValue')}"
             logger.debug(error_message)
-            raise dbterrors.DbtDatabaseError(msg=error_message)
+            raise DbtDatabaseError(msg=error_message)
 
         if self.state in [GlueCursorState.CANCELLED, GlueCursorState.CANCELLING]:
             self._post()
-            raise dbterrors.DbtDatabaseError(
+            raise DbtDatabaseError(
                 msg=f"Statement {self.connection.session_id}.{self.statement_id} cancelled.")
 
         logger.debug("GlueCursor execute successfully")


### PR DESCRIPTION
resolves #433 

### Description
Modified the DbtDatabaseError from dbt to dbt_common

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


FYI : I am not sure wether this change needs testing, if it does, I would be interested in understanding how to!

### Tests that were run locally
Same as in the #433 issue but then got the following output : 
```bash
09:19:04  Running with dbt=1.8.4
09:19:05  Registered adapter: glue=1.8.1
09:19:05  Found 41 models, 2 snapshots, 1 seed, 2 operations, 1 test, 1 source, 1367 macros
09:19:05  
09:19:07  
09:19:07  
09:19:07  1 of 1 START sql incremental model xxx.test_database_error ............ [RUN]
09:19:17  Glue adapter: Glue returned `error` for statement None for code 

spark.sql("""


select "a" as id
""").write.format("delta").mode("overwrite").save("s3://xxx/xxx/test_database_error")
SqlWrapper2.execute("""select 1""")
, AnalysisException: Failed to merge fields 'id' and 'id'. Failed to merge incompatible data types IntegerType and StringType
09:19:17  1 of 1 ERROR creating sql incremental model xxx.test_database_error ... [ERROR in 10.82s]
09:19:35  
09:19:35  
09:19:35  Finished running 1 incremental model, 2 project hooks in 0 hours 0 minutes and 29.55 seconds (29.55s).
09:19:35  
09:19:35  Completed with 1 error and 0 warnings:
09:19:35  
09:19:35    Database Error in model test_database_error (src/models/test_database_error.sql)
  GlueDeltaWriteTableFailed
09:19:35  
09:19:35  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```

The error is well raised