### PR TITLE
fix: add correct import for exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix unraised DbtDatabaseError
 - Fix get_columns_in_relation function to stop returning additional partition columns
 - Fix exceptions import for FailedToConnectError and ExecutableError
+  
 ## v1.8.1
 - Fix typo in README.md
 - Fix unit test failure caused by moto 5 upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Change GlueColumn parent from base Column to SparkColumn
 - Fix unraised DbtDatabaseError
 - Fix get_columns_in_relation function to stop returning additional partition columns
-
+- Fix exceptions import for FailedToConnectError and ExecutableError
 ## v1.8.1
 - Fix typo in README.md
 - Fix unit test failure caused by moto 5 upgrade

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -11,8 +11,10 @@ import threading
 import uuid
 from dbt.adapters.events.logging import AdapterLogger
 
-logger = AdapterLogger("Glue")
+from dbt.adapters.exceptions.connection import FailedToConnectError
+from dbt_common.exceptions import ExecutableError
 
+logger = AdapterLogger("Glue")
 
 class GlueSessionState:
     READY = "READY"

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -143,11 +143,11 @@ class GlueConnection:
         except WaiterError as we:
             # If it comes here, creation failed, do not re-try (loop)
             logger.exception(f'Connect failed to setup a session for {self.session_id}')
-            raise dbterrors.FailedToConnectError(str(we))
+            raise FailedToConnectError(str(we))
         except Exception as e:
             # If it comes here, creation failed, do not re-try (loop)
             logger.exception(f'Error during connect for session {self.session_id}')
-            raise dbterrors.FailedToConnectError(str(e))
+            raise FailedToConnectError(str(e))
 
     def _create_session(
         self,
@@ -228,7 +228,7 @@ class GlueConnection:
             statement.execute()
         except Exception as e:
             logger.error(f"Error in GlueCursor (session_id={self.session_id}, SQLPROXY) execute: {e}")
-            raise dbterrors.ExecutableError(str(e))
+            raise ExecutableError(str(e))
 
         statement = GlueStatement(client=self.client, session_id=self.session_id,
                                   code=f"spark.sql('use {self.credentials.database}')")
@@ -237,7 +237,7 @@ class GlueConnection:
             statement.execute()
         except Exception as e:
             logger.error(f"Error in GlueCursor (session_id={self.session_id}, SQLPROXY) execute: {e}")
-            raise dbterrors.ExecutableError(str(e))
+            raise ExecutableError(str(e))
 
     @property
     def session_id(self):


### PR DESCRIPTION
resolves [#439](https://github.com/aws-samples/dbt-glue/issues/439)

### Description

Add exceptions import:
`
from dbt.adapters.exceptions.connection import FailedToConnectError
from dbt_common.exceptions import ExecutableError
`

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.