### PR TITLE
Allow big seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix null values handling in seeds
 - Fix exceptions import for FailedToConnectError and ExecutableError
 - Fix the case-sensitive comparison on the seed name
+- Allow to load big seed files
 
 ## v1.8.1
 - Fix typo in README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## New version
+- Allow to load big seed files
+
 ## v1.8.6
 - Fix session provisioning timeout and delay handling
 - Add write options for Delta format
@@ -9,7 +12,6 @@
 - Fix null values handling in seeds
 - Fix exceptions import for FailedToConnectError and ExecutableError
 - Fix the case-sensitive comparison on the seed name
-- Allow to load big seed files
 
 ## v1.8.1
 - Fix typo in README.md

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -549,7 +549,7 @@ class GlueAdapter(SQLAdapter):
         statements = []
         for i, csv_chunk in enumerate(csv_chunks):
             is_first = i == 0
-            is_last = i == len(csv_chunk) - 1
+            is_last = i == len(csv_chunks) - 1
             code = "custom_glue_code_for_dbt_adapter\n"
             if is_first:
                 code += f"""

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -545,7 +545,7 @@ class GlueAdapter(SQLAdapter):
         except Exception as e:
             logger.error(e)
 
-    def _map_csv_chunks_to_code(self, csv_chunks: list[list[dict]], session: GlueConnection, model, mode):
+    def _map_csv_chunks_to_code(self, csv_chunks: List[List[dict]], session: GlueConnection, model, mode):
         statements = []
         for i, csv_chunk in enumerate(csv_chunks):
             is_first = i == 0
@@ -582,7 +582,7 @@ SqlWrapper2.execute("""select * from {model["schema"]}.{model["name"]} limit 1""
             statements.append(code)
         return statements
 
-    def _split_csv_records_into_chunks(self, records: list[dict], target_size=60000):
+    def _split_csv_records_into_chunks(self, records: List[dict], target_size=60000):
         chunks = [[]]
         for record in records:
             if len(str([*chunks[-1], record])) > target_size:


### PR DESCRIPTION
resolves #446 

### Description

This pull requests allows to upload seeds with serialized lengths over 68000 characters. It allows so by splitting csv records across chunks which are appended to a session variable on different statement executions.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.