### PR TITLE
 remove update_iceberg_ts from iceberg table when using merge incremental strategy #453 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## New version
+- Remove hard-coded update_iceberg_ts column from the adapter when using merge incremental strategy with iceberg.
+
 ## v1.8.6
 - Fix session provisioning timeout and delay handling
 - Add write options for Delta format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## New version
-- Remove hard-coded update_iceberg_ts column from the adapter when using merge incremental strategy with iceberg.
+- Add a configuration to disable the adding ot the hard-coded update_iceberg_ts column when using merge incremental strategy with iceberg.
 
 ## v1.8.6
 - Fix session provisioning timeout and delay handling

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -951,7 +951,7 @@ spark = SparkSession.builder \\
     .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \\
     .getOrCreate()
 inputDf = spark.sql("""{request}""")
-outputDf = inputDf.drop("dbt_unique_key").withColumn("update_iceberg_ts",current_timestamp())
+outputDf = inputDf.drop("dbt_unique_key")
 '''
         # Use standard table instead of temp view to workaround https://github.com/apache/iceberg/issues/7766
         if session.credentials.glue_version == "4.0":

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -954,10 +954,10 @@ inputDf = spark.sql("""{request}""")
 outputDf = inputDf.drop("dbt_unique_key")
 '''
         # Conditionally add the `update_iceber_ts` column if `include_update_ts` is True
-        if include_update_ts:
+        if include_update_ts == 'True':
             head_code += '''
-        outputDf = outputDf.withColumn("update_iceberg_ts", current_timestamp())
-        '''
+outputDf = outputDf.withColumn("update_iceberg_ts", current_timestamp())
+'''
         # Use standard table instead of temp view to workaround https://github.com/apache/iceberg/issues/7766
         if session.credentials.glue_version == "4.0":
             head_code += f'''outputDf.createOrReplaceTempView("tmp_tmp_{target_relation.name}")

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -3,7 +3,8 @@
   {#-- Validate early so we don't run SQL if the file_format + strategy combo is invalid --#}
   {%- set raw_file_format = config.get('file_format', default='parquet') -%}
   {%- set raw_strategy = config.get('incremental_strategy', default='insert_overwrite') -%}
-  
+  {%- set include_update_ts = config.get('include_update_ts', default='True') -%}
+
   {% if raw_file_format == 'iceberg' %} 
     {%- set file_format = 'iceberg' -%}
     {%- set strategy = raw_strategy -%}
@@ -71,7 +72,7 @@
             {% set build_sql = create_table_as(False, target_relation, sql) %}
         {% endif %}
       {% elif file_format == 'iceberg' %}
-        {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties) }}
+        {{ adapter.iceberg_write(target_relation, sql, unique_key, partition_by, custom_location, strategy, table_properties, include_update_ts) }}
         {% set build_sql = "select * from glue_catalog." + target_relation.schema + "." + target_relation.identifier + " limit 1 "%}
         {%- if expire_snapshots == 'True' -%}
   	      {%- set result = adapter.iceberg_expire_snapshots(target_relation) -%}


### PR DESCRIPTION
resolves #452

### Description
In the current implementation, when using the merge incremental strategy with the Iceberg file format, the adapter automatically adds a column update_iceberg_ts, which is not utilized in the merge process. This causes issues such as breaking schema comparisons between tables in certain scenarios, making the hard-coding of this column restrictive.

This PR removes the hard-coded update_iceberg_ts column from the adapter. If users require this column for specific use cases, they can now add it directly within their model configuration.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.