### PR TITLE
Upgrade default Glue version to 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Adds a helper function to retrieve the Iceberg catalog namespace from the profile.yaml file.
 - Adds merge_exclude_columns and incremental_predicates features.
 - Drop Python 3.8 support
+- Upgrade default Glue version to 5.0
 
 ## v1.8.6
 - Fix session provisioning timeout and delay handling

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -15,7 +15,7 @@ class GlueCredentials(Credentials):
     extra_jars: Optional[str] = None
     idle_timeout: int = 10
     query_timeout_in_minutes: int = 300
-    glue_version: Optional[str] = "4.0"
+    glue_version: Optional[str] = "5.0"
     security_configuration: Optional[str] = None
     connections: Optional[str] = None
     conf: Optional[str] = None

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -15,5 +15,5 @@ class TestGlueCredentials(unittest.TestCase):
         )
         assert credentials.schema == "tests"
         assert credentials.database is None
-        assert credentials.glue_version == "4.0"    # default Glue version is 4.0
+        assert credentials.glue_version == "5.0"    # default Glue version is 5.0
         assert credentials.custom_iceberg_catalog_namespace == "glue_catalog"


### PR DESCRIPTION
### Description

Upgrade default Glue version to 5.0

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.