### PR TITLE
fix 'botocore' not is not defined and add test on GlueConnection.state

### DIFF
--- a/tests/unit/gluedbapi/test_connection.py
+++ b/tests/unit/gluedbapi/test_connection.py
@@ -1,0 +1,14 @@
+import unittest
+from dbt.adapters.glue.credentials import GlueCredentials
+from dbt.adapters.glue.gluedbapi.connection import GlueConnection
+from moto import mock_aws
+import boto3
+
+class TestGlueConnection(unittest.TestCase):
+    @mock_aws
+    def test_connection_state_is_none_for_not_found_session_id(self) -> None:
+        connection = GlueConnection(GlueCredentials())
+        connection._client = boto3.client("glue", region_name="us-east-1")
+        connection._session = {"Session": {"Id": "mock-session-id"}}
+        assert connection.state is None
+        


### PR DESCRIPTION
resolves #513

### Description
I was having some issues related to the mentioned issue when developing some other changes on the adapter, fixed the error I was getting plus refactored to match codebase standard. 
New test was added on GlueConnection for affected use case.
CHANGELOG remains unchanged since change affects unreleased funcionality.


### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.