### PR TITLE
fix list_relations_without_caching for missing database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## New version
 - Correctly handle EntityNotFound when trying to determine session state, setting state to does not exist instead of STOPPED.
-- Allow spawning new isolated sessions for the models that require different session configuration
+- Allow spawning new isolated sessions for the models that require different session configuration.
+- Correctly handle EntityNotFound when listing relations.
 
 ## v1.9.0
 - Allow to load big seed files

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -128,6 +128,8 @@ class GlueAdapter(SQLAdapter):
                         type=self.relation_type_map.get(table.get("TableType")),
                     ))
             return relations
+        except client.exceptions.EntityNotFoundException as e:
+            return []
         except Exception as e:
             logger.error(e)
 


### PR DESCRIPTION
resolves #516

### Description

The method ```list_relations_without_caching``` is returning ```None``` when trying to list relations from a non existing database, this causes a failure on the base adapter when computing the schema cache. 
This pr captures the ```EntityNotFoundException``` exception to return an empty list for such cases. This behaviour is consistent with other adapter implementations, such as dbt-spark where ```Database '<database name>' not found``` is captured to return empty array.

### Checklist

- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.