### PR TITLE
Fix the get_columns_in_relation function error when on_schema_change is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Future Release
 - Allow spawning new isolated sessions for the models that require different session configuration
+- Fix the get_columns_in_relation function error when on_schema_change is specified
 
 ## v1.9.0
 - Allow to load big seed files

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -228,7 +228,7 @@ class GlueAdapter(SQLAdapter):
         computed_schema = self.__compute_schema_based_on_type(schema=relation.schema, identifier=relation.identifier)
 
 
-        if relation.identifier.endswith('_tmp'):
+        if relation.identifier.endswith('_tmp') and not relation.identifier.endswith('_dbt_tmp'):
             code = f"""describe {relation.identifier}"""
         else:
             code = f"""describe {computed_schema}.{relation.identifier}"""

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -226,7 +226,14 @@ class GlueAdapter(SQLAdapter):
         logger.debug("get_columns_in_relation called")
         session, client = self.get_connection()
         computed_schema = self.__compute_schema_based_on_type(schema=relation.schema, identifier=relation.identifier)
-        code = f"""describe {computed_schema}.{relation.identifier}"""
+
+
+        if relation.identifier.endswith('_tmp'):
+            code = f"""describe {relation.identifier}"""
+        else:
+            code = f"""describe {computed_schema}.{relation.identifier}"""
+        logger.debug(f"code: {code}")
+
         columns = []
         try:
             response = session.cursor().execute(code)


### PR DESCRIPTION
resolves #503

### Description

The error occurs when DESCRIBE statement is triggered.
The fix is to change the table identifier for tmp table created for incremental model.
Currently, the temp table for incremental has suffix of `_tmp`, and the temp table for snapshot has suffix of `_dbt_tmp`
The fix is only for the former. 

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.