### PR TITLE
Add refresh table when missing columns are detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 - Correctly handle EntityNotFound when trying to determine session state, setting state to does not exist instead of STOPPED.
 - Allow spawning new isolated sessions for the models that require different session configuration.
 - Correctly handle EntityNotFound when listing relations.
-- Added configuration property to allow spark casting of seed column types.
+- Add configuration property to allow spark casting of seed column types.
 - Fix the get_columns_in_relation function error when on_schema_change is specified.
 - Upgrade dependencies: dbt-core 1.9.2, dbt-spark 1.9.1, dbt-tests-adapter 1.11.0, mypy 1.15.0, moto 5.0.28, and black 25.1.0.
 - Fix the temporary view creation issue when using schema_on_change
 - Fix error handling and logging
-- Adds update_iceberg_ts column with an add_iceberg_timestamp option.
+- Add update_iceberg_ts column with an add_iceberg_timestamp option.
+- Add refresh table when missing columns are detected
 
 ## v1.9.0
 - Allow to load big seed files

--- a/dbt/include/glue/macros/materializations/snapshot.sql
+++ b/dbt/include/glue/macros/materializations/snapshot.sql
@@ -159,6 +159,12 @@
 
       {% do create_columns(target_relation, missing_columns) %}
 
+      {% if missing_columns|length > 0 %}
+        {% call statement('refresh_table_metadata') %}
+          refresh table {{ target_relation }}
+        {% endcall %}
+      {% endif %}
+
       {% set source_columns = adapter.get_columns_in_relation(staging_table)
                                    | rejectattr('name', 'equalto', 'dbt_change_type')
                                    | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')


### PR DESCRIPTION
This PR adds refresh table when missing columns are detected

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.