### PR TITLE
Fix ALTER TABLE ADD COLUMN returning None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix error handling and logging
 - Add update_iceberg_ts column with an add_iceberg_timestamp option.
 - Add refresh table when missing columns are detected
+- Fix ALTER TABLE ADD COLUMN returning None
 
 ## v1.9.0
 - Allow to load big seed files


### PR DESCRIPTION
### Description

This PR fixes the issue 2 described here: https://github.com/aws-samples/dbt-glue/issues/486

The macro `spark__alter_relation_add_remove_columns` is implemented in dbt-spark and it calls run_query method. However, in dbt-glue, `run_query` method expects results including metadata, alter table always fails because of this.

To avoid that, we overwrite `spark__alter_relation_add_remove_columns`  in adapters.sql.

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.