### PR TITLE
Remove database and schema from {{full_source_relation}} when it refers to a temporary view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix invalid Spark relation type: iceberg_table
 - Fix Iceberg snapshot issue of incorrect DROP VIEW calls
 - Upgrade dependencies: dbt-core 1.9.4, dbt-spark 1.9.2, moto 5.1.3.
+- Fix Insert Overwrite Strategy when source refers to a temporary view. 
 
 ## v1.9.2
 - Correctly handle EntityNotFound when trying to determine session state, setting state to does not exist instead of STOPPED.

--- a/dbt/include/glue/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/glue/macros/materializations/incremental/strategies.sql
@@ -7,6 +7,8 @@
     {%- if file_format == 'iceberg' -%}
         {%- set full_target_relation = glue__make_target_relation(target_relation, file_format) -%}
         {%- set full_source_relation = glue__make_target_relation(source_relation, file_format) -%}
+     {%- else -%}
+        {%- set full_source_relation = full_source_relation.include(database=false, schema=false) -%}
     {%- endif -%}
     set hive.exec.dynamic.partition.mode=nonstrict
     dbt_next_query


### PR DESCRIPTION

resolves [#550](https://github.com/aws-samples/dbt-glue/issues/550)

### Description

Added a conditional treatment in get_insert_overwrite_sql (lines 1011) to remove the schema and database from {{full_source_relation}} when it refers to a temporary view

### Checklist

- 

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.
