### PR TITLE
[glue__make_temp_relation] Return the tmp_relation object without database and schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix invalid Spark relation type: iceberg_table
 - Fix Iceberg snapshot issue of incorrect DROP VIEW calls
 - Upgrade dependencies: dbt-core 1.9.4, dbt-spark 1.9.2, moto 5.1.3.
+- Fix [glue__make_temp_relation] Return the tmp_relation object without database and schema
 
 ## v1.9.2
 - Correctly handle EntityNotFound when trying to determine session state, setting state to does not exist instead of STOPPED.

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -89,6 +89,7 @@
 {% macro glue__make_temp_relation(base_relation, suffix) %}
     {% set tmp_identifier = base_relation.identifier ~ suffix %}
     {% set tmp_relation = base_relation.incorporate(path={"schema": base_relation.schema, "identifier": tmp_identifier}) -%}
+    {%- set tmp_relation = tmp_relation.include(database=false, schema=false) -%}
     {% do return(tmp_relation) %}
 {% endmacro %}
 


### PR DESCRIPTION
resolves [#550](https://github.com/aws-samples/dbt-glue/issues/550)

### Description

Added a conditional treatment to return the  {{tmp_relation}} without database and schema

### Checklist

- 

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.



