### PR TITLE
Temp schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## dbt-glue next
+- Allow temporary tables to be created in different schema/database than target model using profile temp-schema variable
+
 ## v1.9.4
 - Reduce debug logging
 - Fix invalid Spark relation type: iceberg_table

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-agg
 
 # dbt-glue
 
+test
+
 The `dbt-glue` package implements the [dbt adapter](https://docs.getdbt.com/docs/contributing/building-a-new-adapter) protocol for AWS Glue's Spark engine. 
 It supports running dbt against Spark, through the new Glue Interactive Sessions API.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ dbt is the T in ELT. Organize, cleanse, denormalize, filter, rename, and pre-agg
 
 # dbt-glue
 
-test
-
 The `dbt-glue` package implements the [dbt adapter](https://docs.getdbt.com/docs/contributing/building-a-new-adapter) protocol for AWS Glue's Spark engine. 
 It supports running dbt against Spark, through the new Glue Interactive Sessions API.
 

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -26,6 +26,7 @@ class GlueCredentials(Credentials):
     tags: Optional[str] = None
     database: Optional[str] = None  # type: ignore
     schema: Optional[str] = None  # type: ignore
+    temp_schema: Optional[str] = None
     seed_format: Optional[str] = "parquet"
     seed_mode: Optional[str] = "overwrite"
     default_arguments: Optional[str] = None
@@ -75,6 +76,7 @@ class GlueCredentials(Credentials):
             'worker_type',
             'session_provisioning_timeout_in_seconds',
             'schema',
+            'temp_schema',
             'location',
             'extra_jars',
             'idle_timeout',

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -64,8 +64,10 @@ class GlueConnection:
 
         if self.credentials.enable_session_per_model:
             if self._session_id_suffix:
+                # Glue Session Names must not have periods, so replace with underscores
+                sanitized_suffix = self._session_id_suffix.replace('.', '_')
                 # Suffix would be the model name, already unique
-                id = f'{id}__{self._session_id_suffix}'
+                id = f'{id}__{sanitized_suffix}'
             else:
                 # Ensure no duplicate session id across models
                 id = f'{id}__{iam_role_name}__{uuid.uuid4()}'

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -88,7 +88,9 @@
 
 {% macro glue__make_temp_relation(base_relation, suffix) %}
     {% set tmp_identifier = base_relation.identifier ~ suffix %}
-    {% set tmp_relation = base_relation.incorporate(path={"schema": base_relation.schema, "identifier": tmp_identifier}) -%}
+    {#-- If target profile has temp_schema set, allows _tmp relations to be built in separate catalog when physicalized #}
+    {% set tmp_schema = target.temp_schema if target.temp_schema else base_relation.schema %}
+    {% set tmp_relation = base_relation.incorporate(path={"schema": tmp_schema, "identifier": tmp_identifier}) -%}
     {% do return(tmp_relation) %}
 {% endmacro %}
 

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -87,11 +87,11 @@
 {% endmacro %}
 
 {% macro glue__make_temp_relation(base_relation, suffix) %}
-    {% set tmp_identifier = base_relation.identifier ~ suffix %}
-    {#-- If target profile has temp_schema set, allows _tmp relations to be built in separate catalog when physicalized #}
-    {% set tmp_schema = target.temp_schema if target.temp_schema else base_relation.schema %}
-    {% set tmp_relation = base_relation.incorporate(path={"schema": tmp_schema, "identifier": tmp_identifier}) -%}
-    {% do return(tmp_relation) %}
+  {% set tmp_identifier = base_relation.identifier ~ suffix %}
+  {#-- If target profile has temp_schema set, allows _tmp relations to be built in separate catalog when physicalized #}
+  {% set tmp_schema = target.temp_schema if target.temp_schema else base_relation.schema %}
+  {% set tmp_relation = base_relation.incorporate(path={"schema": tmp_schema, "identifier": tmp_identifier}) -%}
+  {% do return(tmp_relation) %}
 {% endmacro %}
 
 {% macro glue__create_temporary_view(relation, sql) -%}

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -43,7 +43,7 @@ def dbt_profile_target(unique_schema, use_arrow):
         'location': get_s3_location(),
         'datalake_formats': 'delta,iceberg',
         'conf': f"spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension,org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog --conf spark.sql.legacy.allowNonEmptyLocationInCTAS=true --conf spark.sql.catalog.glue_catalog=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.glue_catalog.warehouse={get_s3_location()} --conf spark.sql.catalog.glue_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog --conf spark.sql.catalog.glue_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO --conf spark.sql.sources.partitionOverwriteMode=dynamic",
-        'glue_session_reuse': False,
+        'glue_session_reuse': True,
         'use_arrow': use_arrow
     }
 


### PR DESCRIPTION
resolves #569

### Description

I added the ability for one to specify a different schema for temporary tables to be created in so that they can be physically isolated under different management and lifecycle rules and security policies than the target Glue database within the same Glue catalog.  For example, if you have a database in Lake Formation in a different AWS account that is cataloged in your local Glue catalog through a resource link, and this is where your target data assets are managed, but you don't want to muddy that database with temporary tables that may have restrictions through Lake Formation, you can specify a different schema/database in the same catalog that would not be the resource link.  This way as well, if data files are not cleaned up appropriately, they can be easily managed outside of your target data assets.  

How to set:  Add the following variable in your iceberg target profile, as example below:

```
your_project_name:
  target: your_target_env
  outputs:
    your_target_env:
      type: glue
      role_arn: "arn:aws:iam::999999999999:role/your-glue-role"
      ...
      schema: "rl_my_resource_link_to_lake_formation"
      temp_schema: "my_local_temp_table_database"
      ...
      datalake_formats: "iceberg"
      conf: >
        spark.sql.catalog.edla_catalog=org.apache.iceberg.spark.SparkCatalog 
        --conf ...
```

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.