### PR TITLE
Only read session-relevant meta config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## dbt-glue next
 - Allow temporary tables to be created in different schema/database than target model using profile temp-schema variable
 - Add experimental Python model support with Iceberg file format (requires AWS Glue 4.0+)
+- Fix issue where including unrelated values in `meta` section would create new sessions when `glue_session_id` is set
 
 ## v1.9.4
 - Reduce debug logging

--- a/dbt/adapters/glue/credentials.py
+++ b/dbt/adapters/glue/credentials.py
@@ -70,7 +70,7 @@ class GlueCredentials(Credentials):
                 f"On Spark, database must be omitted or have the same value as"
                 f" schema."
             )
-        self.database = None
+        self.database = self.schema
 
     def _connection_keys(self):
         """ Keys to show when debugging """


### PR DESCRIPTION
resolves #547

### Description

Starting in v1.9.2, the presence of a `meta` element on any model config would cause the Glue client to create a new Glue session, even if the `mdta` element did not contain any parameters relevant to Glue sessions.

The `meta` element on dbt models is generic, and can be used by different plugins to introduce different behavior. Coupling the mere presence of `meta` to separate Glue sessions is problematic for users on v1.9.0 and earlier who were using `meta` for other purposes, because new sessions are spun up rather than reused, resulting in longer runtimes, and increased cardinality of sessions IDs propagates to CloudWatch metric cardinality.

This commit changes the interpretation of `meta` such that new sessions are only created if `meta` contains config keys that actually affect Glue session configuration.

Additionally, it appears that the existing unit tests did not cover the behavior of Glue session creation, making it difficult to verify changes in behavior for Glue session arguments. This commit sets up spies to observe the parameters passed to `boto3.GlueClient.create_session` in unit tests. The previous test for the `meta` parameter has been replaced because it was testing input configuration and not outgoing behavior.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.