### PR TITLE
Fix merge strategy with schema changes for Iceberg tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Allow temporary tables to be created in different schema/database than target model using profile temp-schema variable
 - Add experimental Python model support with Iceberg file format (requires AWS Glue 4.0+)
 - Add experimental Amazon S3 Tables support with `file_format='s3tables'`
+- Fix merge strategy with schema changes for Iceberg tables
 
 ## v1.9.4
 - Reduce debug logging

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -75,12 +75,7 @@
           {%- do process_schema_changes(on_schema_change, tmp_relation, target_relation) -%}
 
           {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
-          {%- set dest_cols_csv = dest_columns | map(attribute='name') | join(', ') -%}
-          {%- set full_tmp_relation = glue__make_target_relation(tmp_relation, file_format) -%}
-          {%- set full_target_relation = glue__make_target_relation(target_relation, file_format) -%}
-          {% set build_sql %}
-          insert into {{ full_target_relation }} ({{ dest_cols_csv }}) select {{ dest_cols_csv }} from {{ full_tmp_relation }}
-          {% endset %}
+          {% set build_sql = dbt_glue_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, incremental_predicates, dest_columns) %}
 
         {% else %}
           {%- if language != 'python' -%}


### PR DESCRIPTION
Fixes issue where incremental_strategy='merge' + on_schema_change='append_new_columns' was incorrectly using INSERT INTO instead of MERGE INTO for Iceberg tables.

resolves #571

### Description

- Fix incremental.sql to use proper strategy instead of hardcoded INSERT when schema changes occur
- Update get_merge_sql to handle explicit column lists for schema changes
- Add dest_columns parameter to dbt_glue_get_incremental_sql
- Add test case for merge + schema change combination to prevent regression

### Checklist

- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.