### PR TITLE
return RelationType.Table when file_format == 's3tables'

### DIFF
--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -11,7 +11,7 @@ import agate
 from concurrent.futures import Future
 
 from dbt.adapters.base import available, PythonJobHelper
-from dbt.adapters.base.relation import BaseRelation, InformationSchema
+from dbt.adapters.base.relation import BaseRelation, InformationSchema, RelationType
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.glue import GlueConnectionManager
 from dbt.adapters.glue.column import GlueColumn
@@ -895,9 +895,9 @@ SqlWrapper2.execute("""select 1""")
                         DatabaseName=schema,
                         Name=relation.name
                     )
-                    return 's3_table'
+                    return RelationType.Table
                 except Exception as e:
-                    return 's3_table'  # Assume it's S3 table even if get_table fails
+                    return RelationType.Table
 
         schema = self._strip_catalog_from_schema(relation.schema)
 


### PR DESCRIPTION
The latest version `1.10.11` does not work when using s3 tables as the returned typer from `adapter.get_table_type` is not one of the allowed enums in `RelationType`.

### Description

Instead of returning "s3_tables" returns `RelationType.Table` which in my testing resolved the error I was getting when running models:

```
Field "type" of type Optional[RelationType] in SparkRelation has invalid value 's3_table'
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.