### PR TITLE
feat: ability to set configurations in python model

### DIFF
--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -192,8 +192,6 @@ class GlueConnection:
 
         if (self.credentials.datalake_formats is not None):
             args["--datalake-formats"] = f"{self.credentials.datalake_formats}"
-        if (self.credentials.datalake_formats is not None):
-            args["--datalake-formats"] = f"{self.credentials.datalake_formats}"
 
         self._session = self.client.create_session(
             Id=session_id,

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from dbt import exceptions as dbterrors
 import boto3
 from botocore.config import Config
 from botocore.exceptions import WaiterError
@@ -391,8 +390,15 @@ class GlueConnection:
 
     def _string_to_dict(self, value_to_convert):
         value_in_dictionary = {}
-        for i in value_to_convert.split(","):
-            value_in_dictionary[i.split("=")[0].strip('\'').replace("\"", "")] = i.split("=")[1].strip('"\'')
+        for i in value_to_convert.split("--"):
+            i = i.strip()
+            if i == "":
+                continue
+            i = f"--{i}"
+            if i[-1] == ',':
+                i=i.rstrip(",")
+            value_in_dictionary[i.split(":")[0].strip('\'').replace("\"", "")] = i.split(":")[1].strip('"\'')
+         
         return value_in_dictionary
 
 

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -168,6 +168,9 @@ class GlueConnection:
         if (self._create_session_config["extra_py_files"] is not None):
             args["--extra-py-files"] = f"{self._create_session_config['extra_py_files']}"
 
+        if (self._create_session_config["packages"] is not None):
+              args["--additional-python-modules"] = ",".join(self._create_session_config["packages"])
+
         additional_args = {}
         additional_args["NumberOfWorkers"] = self._create_session_config["workers"]
         additional_args["WorkerType"] = self._create_session_config["worker_type"]
@@ -187,6 +190,8 @@ class GlueConnection:
         if (self._create_session_config["tags"] is not None):
             additional_args["Tags"] = self._string_to_dict(self._create_session_config["tags"])
 
+        if (self.credentials.datalake_formats is not None):
+            args["--datalake-formats"] = f"{self.credentials.datalake_formats}"
         if (self.credentials.datalake_formats is not None):
             args["--datalake-formats"] = f"{self.credentials.datalake_formats}"
 

--- a/dbt/adapters/glue/python_submissions.py
+++ b/dbt/adapters/glue/python_submissions.py
@@ -1,7 +1,5 @@
 import time
-import time
-import uuid
-from typing import Any, Dict
+from typing import Dict
 
 from dbt.adapters.base import PythonJobHelper
 from dbt_common.exceptions import DbtRuntimeError
@@ -10,13 +8,19 @@ from dbt.adapters.glue import GlueCredentials
 
 class GluePythonJobHelper(PythonJobHelper):
     def __init__(self, parsed_model: Dict, credentials: GlueCredentials) -> None:
-        self.credentials = credentials
         self.identifier = parsed_model["alias"]
         self.schema = parsed_model["schema"]
         self.parsed_model = parsed_model
-        
-        # Extract packages from model config (dbt Core standard)
-        self.packages = parsed_model.get("config", {}).get("packages", [])
+
+        # Extracting additional args that were provided in `dbt.config()` 
+        # it will overwrite all previously set args in GlueCredentials, making
+        # `dbt.config` have the same structure as sql model {{ config }}
+        config = parsed_model.get("config", {})
+        if config:
+            for k, v in config.items():
+                setattr(credentials, k, v)
+
+        self.credentials = credentials
         
         self.timeout = self.parsed_model["config"].get("timeout", 60 * 60)  # Default 1 hour
         self.polling_interval = 10

--- a/tests/unit/gluedbapi/test_connection.py
+++ b/tests/unit/gluedbapi/test_connection.py
@@ -1,10 +1,12 @@
 import unittest
 from unittest import mock
 
+import boto3
+from moto import mock_aws
+
 from dbt.adapters.glue.credentials import GlueCredentials
 from dbt.adapters.glue.gluedbapi.connection import GlueConnection
-from moto import mock_aws
-import boto3
+
 
 class TestGlueConnection(unittest.TestCase):
     @mock_aws
@@ -16,7 +18,9 @@ class TestGlueConnection(unittest.TestCase):
 
     @mock.patch("dbt.adapters.glue.gluedbapi.connection.get_session_waiter")
     @mock.patch("dbt.adapters.glue.gluedbapi.connection.boto3")
-    def test_client_uses_credentials_retry_settings(self, mock_boto3, mock_waiter) -> None:
+    def test_client_uses_credentials_retry_settings(
+        self, mock_boto3, mock_waiter
+    ) -> None:
         mock_waiter.return_value = mock.Mock()
         mock_session = mock_boto3.session.Session.return_value
         mock_client = mock_session.client.return_value
@@ -36,3 +40,51 @@ class TestGlueConnection(unittest.TestCase):
         retries = kwargs["config"].retries
         assert retries["max_attempts"] == 4
         assert retries["mode"] == "standard"
+
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.get_session_waiter")
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.boto3")
+    def test_create_session_with_packages(self, mock_boto3, mock_waiter) -> None:
+        mock_waiter.return_value = mock.Mock()
+        mock_session = mock_boto3.session.Session.return_value
+        mock_client = mock_session.client.return_value
+
+        credentials = GlueCredentials(
+            role_arn="arn:aws:iam::123456789012:role/GlueRole",
+            region="us-east-1",
+            workers=2,
+            worker_type="G.1X",
+            schema="test_schema",
+            packages=["validoopsie", "asciimatics"],
+        )
+
+        connection = GlueConnection(credentials)
+        connection._create_session("test-session-id")
+
+        mock_client.create_session.assert_called_once()
+        call_kwargs = mock_client.create_session.call_args[1]
+
+        default_args = call_kwargs["DefaultArguments"]
+        assert "--additional-python-modules" in default_args
+        assert default_args["--additional-python-modules"] == "validoopsie,asciimatics"
+
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.get_session_waiter")
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.boto3")
+    def test_create_session_without_packages(self, mock_boto3, mock_waiter) -> None:
+        mock_waiter.return_value = mock.Mock()
+        mock_session = mock_boto3.session.Session.return_value
+        mock_client = mock_session.client.return_value
+
+        credentials = GlueCredentials(
+            role_arn="arn:aws:iam::123456789012:role/GlueRole",
+            region="us-east-1",
+            workers=2,
+            worker_type="G.1X",
+            schema="test_schema",
+        )
+
+        connection = GlueConnection(credentials)
+        connection._create_session("test-session-id")
+
+        call_kwargs = mock_client.create_session.call_args[1]
+        default_args = call_kwargs["DefaultArguments"]
+        assert "--additional-python-modules" not in default_args

--- a/tests/unit/gluedbapi/test_connection.py
+++ b/tests/unit/gluedbapi/test_connection.py
@@ -88,3 +88,35 @@ class TestGlueConnection(unittest.TestCase):
         call_kwargs = mock_client.create_session.call_args[1]
         default_args = call_kwargs["DefaultArguments"]
         assert "--additional-python-modules" not in default_args
+
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.get_session_waiter")
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.boto3")
+    def test_create_session_with_default_arguments_dict_and_list_values(
+        self, mock_boto3, mock_waiter
+    ) -> None:
+        """Test that default_arguments as a dict with list values joins them into comma-separated strings."""
+        mock_waiter.return_value = mock.Mock()
+        mock_session = mock_boto3.session.Session.return_value
+        mock_client = mock_session.client.return_value
+
+        credentials = GlueCredentials(
+            role_arn="arn:aws:iam::123456789012:role/GlueRole",
+            region="us-east-1",
+            workers=2,
+            worker_type="G.1X",
+            schema="test_schema",
+            default_arguments="--enable-metrics: true, --additional-python-modules:numpy,pandas,scikit-learn",
+        )
+
+        connection = GlueConnection(credentials)
+        connection._create_session("test-session-id")
+
+        mock_client.create_session.assert_called_once()
+        call_kwargs = mock_client.create_session.call_args[1]
+        default_args = call_kwargs["DefaultArguments"]
+
+        assert default_args["--enable-metrics"] == "true"
+        assert "--additional-python-modules" in default_args
+        assert (
+            default_args["--additional-python-modules"] == "numpy,pandas,scikit-learn"
+        )

--- a/tests/unit/test_python_submissions.py
+++ b/tests/unit/test_python_submissions.py
@@ -139,7 +139,7 @@ def test_glue_python_job_helper_with_packages(mock_glue_connection_class, mock_c
     assert "import numpy as np; print('Hello with packages!')" in run_statement_args['Code']
     
     # Verify packages were extracted correctly
-    assert helper.packages == ["numpy", "pandas", "scikit-learn"]
+    assert helper.credentials.packages == ["numpy", "pandas", "scikit-learn"]
 
 def test_glue_python_job_helper_packages_extraction(mock_credentials):
     """Test that packages are properly extracted from model config"""
@@ -153,14 +153,15 @@ def test_glue_python_job_helper_packages_extraction(mock_credentials):
     }
     
     helper = GluePythonJobHelper(parsed_model_with_packages, mock_credentials)
-    assert helper.packages == ["numpy", "pandas"]
+    assert helper.credentials.packages == ["numpy", "pandas"]
     
+def test_glue_python_job_helper_packages_extraction(mock_credentials):
+    """Test that packages are properly extracted from model config"""
     # Test without packages
     parsed_model_without_packages = {
         "alias": "test_model",
         "schema": "test_schema",
         "config": {}
     }
-    
     helper = GluePythonJobHelper(parsed_model_without_packages, mock_credentials)
-    assert helper.packages == []
+    assert helper.credentials.packages == None


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

* One can set a full configuration of a dbt session through `dbt.config` inside of a python model
* Fixed profiles.yml improperly being set with Python model when creating an interactive session

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.