### PR TITLE
fix: ref() and source() in Python models 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.20
+
+- Fixed `ref()` and `source()` in Python models to use dbt-core's resolved functions
+
 ## 1.10.19
 
 - Made GetStatement polling rate and boto3 retry settings configurable in the dbt profile using `statement_poll_interval`, `boto_retry_mode` and `boto_retry_max_attempts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 1.10.20
+## dbt-glue next
 
-<<<<<<< fix_table_ref_source_issue
 - Fixed `ref()` and `source()` in Python models to use dbt-core's resolved functions
-=======
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
->>>>>>> main
 
 ## 1.10.19
 

--- a/dbt/include/glue/macros/materializations/python/python_utils.sql
+++ b/dbt/include/glue/macros/materializations/python/python_utils.sql
@@ -13,24 +13,28 @@ schema = "{{ target_relation.schema }}"
 model_name = "{{ target_relation.identifier }}"
 print("DEBUG: Setting up model in schema: " + schema)
 
+# Save references to dbt-core's resolved ref/source functions
+_dbt_core_ref = ref
+_dbt_core_source = source
+
 class dbtObj:
     def __init__(self, table_function, schema, model_name):
         self.table_function = table_function
         self.schema = schema
         self.model_name = model_name
         self.this = schema + "." + model_name
-        
+
     def config(self, **config_args):
         # This is a placeholder for dbt config in Python models
         print("DEBUG: dbt.config called with:", config_args)
         pass
-        
-    def ref(self, name):
-        return self.table_function(name)
-        
-    def source(self, source_name, table_name):
-        return self.table_function(source_name + "." + table_name)
-        
+
+    def ref(self, *args, **kwargs):
+        return _dbt_core_ref(*args, **kwargs, dbt_load_df_function=self.table_function)
+
+    def source(self, *args):
+        return _dbt_core_source(*args, dbt_load_df_function=self.table_function)
+
     def is_incremental(self):
         # Check if the target table exists by trying to query it
         try:
@@ -131,10 +135,10 @@ print("DEBUG: materialized =", materialized)
 print("DEBUG: incremental_strategy =", incremental_strategy)
 print("DEBUG: unique_key =", unique_key)
 
-is_incremental_merge = (materialized == "incremental" and 
-                       incremental_strategy == "merge" and 
-                       unique_key != "None" and 
-                       unique_key != "none" and 
+is_incremental_merge = (materialized == "incremental" and
+                       incremental_strategy == "merge" and
+                       unique_key != "None" and
+                       unique_key != "none" and
                        unique_key != "")
 
 print("DEBUG: is_incremental_merge =", is_incremental_merge)
@@ -152,7 +156,7 @@ try:
     if is_incremental_merge and table_exists:
         # For incremental merge, use MERGE INTO statement
         print("DEBUG: Using MERGE INTO for incremental update")
-        
+
         # Parse unique_key (handle both string and list formats)
         if unique_key.startswith('[') and unique_key.endswith(']'):
             # List format: ['id'] or ['id', 'name']
@@ -161,15 +165,15 @@ try:
         else:
             # String format: 'id'
             unique_key_list = [unique_key]
-        
+
         print("DEBUG: unique_key_list =", unique_key_list)
-        
+
         # Create the merge conditions
         merge_conditions = []
         for key in unique_key_list:
             merge_conditions.append(f"target.{key} = source.{key}")
         merge_condition = " AND ".join(merge_conditions)
-        
+
         merge_sql = f"""
         MERGE INTO {table_name} AS target
         USING temp_python_df AS source
@@ -177,11 +181,11 @@ try:
         WHEN MATCHED THEN UPDATE SET *
         WHEN NOT MATCHED THEN INSERT *
         """
-        
+
         print("DEBUG: Executing MERGE SQL:", merge_sql)
         spark.sql(merge_sql)
         print("DEBUG: MERGE completed successfully")
-        
+
     else:
         # For first run or non-merge strategies, use CREATE OR REPLACE
         print("DEBUG: Using CREATE OR REPLACE TABLE for full refresh")
@@ -189,11 +193,11 @@ try:
         print("DEBUG: Executing SQL:", create_sql)
         spark.sql(create_sql)
         print("DEBUG: Iceberg table created successfully")
-    
+
     # Clean up temp view to avoid conflicts with subsequent models
     spark.sql("DROP VIEW IF EXISTS temp_python_df")
     print("DEBUG: Cleaned up temp view")
-    
+
 except Exception as e:
     print("DEBUG: Error creating Iceberg table:", str(e))
     print("DEBUG: Trying with CREATE TABLE IF NOT EXISTS...")
@@ -201,11 +205,11 @@ except Exception as e:
         create_sql_fallback = "CREATE TABLE IF NOT EXISTS " + table_name + " USING ICEBERG AS SELECT * FROM temp_python_df"
         spark.sql(create_sql_fallback)
         print("DEBUG: Iceberg table created with IF NOT EXISTS")
-        
+
         # Clean up temp view
         spark.sql("DROP VIEW IF EXISTS temp_python_df")
         print("DEBUG: Cleaned up temp view")
-        
+
     except Exception as e2:
         print("DEBUG: Both Iceberg approaches failed:", str(e2))
         # For Iceberg, we must use SQL - no fallback to saveAsTable

--- a/tests/unit/macros/test_python_utils.py
+++ b/tests/unit/macros/test_python_utils.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import Mock
+
+
+class TestDbtObjRefSource(unittest.TestCase):
+    def setUp(self):
+        self.refs = {"stg_orders": "analytics.stg_orders"}
+        self.sources = {"raw_alias.orders": "production_raw.orders"}
+        self.table_fn = Mock(side_effect=lambda t: f"DF<{t}>")
+
+        # Mirrors the generated code in python_utils.sql
+        _dbt_core_ref = self._mock_core_ref
+        _dbt_core_source = self._mock_core_source
+        table_fn = self.table_fn
+
+        class dbtObj:
+            def __init__(self):
+                self.table_function = table_fn
+
+            def ref(self, *args, **kwargs):
+                return _dbt_core_ref(
+                    *args, **kwargs, dbt_load_df_function=self.table_function
+                )
+
+            def source(self, *args):
+                return _dbt_core_source(*args, dbt_load_df_function=self.table_function)
+
+        self.dbt = dbtObj()
+
+    def _mock_core_ref(self, *args, **kwargs):
+        key = ".".join(args)
+        version = kwargs.get("v") or kwargs.get("version")
+        if version:
+            key += f".v{version}"
+        return kwargs["dbt_load_df_function"](self.refs[key])
+
+    def _mock_core_source(self, *args, dbt_load_df_function):
+        key = ".".join(args)
+        return dbt_load_df_function(self.sources[key])
+
+    def test_ref(self):
+        result = self.dbt.ref("stg_orders")
+        self.table_fn.assert_called_once_with("analytics.stg_orders")
+        self.assertEqual(result, "DF<analytics.stg_orders>")
+
+    def test_ref_with_version(self):
+        self.refs["stg_orders.v2"] = "analytics.stg_orders_v2"
+        self.dbt.ref("stg_orders", v=2)
+        self.table_fn.assert_called_once_with("analytics.stg_orders_v2")
+
+    def test_source_resolves_schema_not_alias(self):
+        """The core bug: source alias != schema. dbt-core resolves to the real schema."""
+        result = self.dbt.source("raw_alias", "orders")
+        self.table_fn.assert_called_once_with("production_raw.orders")
+        self.assertEqual(result, "DF<production_raw.orders>")


### PR DESCRIPTION
fix: ref() and source() in Python models to use dbt-core's resolved functions

The previous implementation constructed table references manually. When calling `source("my_source_aliase", "my_table")` it would literally pass those string into `spark.table` resulting in a call `spark.table("my_source_aliase"."my_table")`.

This fix will resolve this issue with reutilization of

```py

def ref(*args, **kwargs):
    refs = {"my_ref_table": "my_schema.my_ref_table"}
    key = '.'.join(args)
    version = kwargs.get("v") or kwargs.get("version")
    if version:
        key += f".v{version}"
    dbt_load_df_function = kwargs.get("dbt_load_df_function")
    return dbt_load_df_function(refs[key])

def source(*args, dbt_load_df_function):
    sources = {"my_source_aliase.my_source_table": "my_source_schema.my_source_table"}
    key = '.'.join(args)
    return dbt_load_df_function(sources[key])
```

**NOTE:** that instead of having `my_source_aliase` it points to `my_source_schema`, which would solve the issue of an incorrect pointer with `spark.table`, outputting `spark.table("my_source_schema"."my_source_table")`

This took me ages to figure out, was so confused on why there was source declaration.

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.