### PR TITLE
Fix seed not respecting alias config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed `ref()` and `source()` in Python models to use dbt-core's resolved functions
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
+- Fixed seed `alias` config not being respected, causing tables to be created with the original seed name instead of the alias
 
 ## 1.10.19
 

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -668,18 +668,18 @@ df = df.selectExpr({cast_columns})
 df = spark.createDataFrame(csv)
 """
                 code += f'''
-table_name = '{model["schema"]}.{model["name"]}'
-if (spark.sql("show tables in {model["schema"]}").where("tableName == lower('{model["name"]}')").count() > 0):
+table_name = '{model["schema"]}.{model["alias"]}'
+if (spark.sql("show tables in {model["schema"]}").where("tableName == lower('{model["alias"]}')").count() > 0):
     df.write\
         .mode("{session.credentials.seed_mode}")\
         .format("{session.credentials.seed_format}")\
         .insertInto(table_name, overwrite={mode})
 else:
     df.write\
-        .option("path", "{session.credentials.location}/{model["schema"]}/{model["name"]}")\
+        .option("path", "{session.credentials.location}/{model["schema"]}/{model["alias"]}")\
         .format("{session.credentials.seed_format}")\
         .saveAsTable(table_name)
-SqlWrapper2.execute("""select * from {model["schema"]}.{model["name"]} limit 1""")
+SqlWrapper2.execute("""select * from {model["schema"]}.{model["alias"]} limit 1""")
 '''
             statements.append(code)
         return statements

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -99,7 +99,7 @@ class TestGlueAdapter(unittest.TestCase):
     def test_create_csv_table_slices_big_datasets(self):
         config = self._get_config()
         adapter = GlueAdapter(config, get_context("spawn"))
-        model = {"name": "mock_model", "schema": "mock_schema"}
+        model = {"name": "mock_model", "alias": "mock_model", "schema": "mock_schema"}
         session_mock = Mock()
         adapter.get_connection = lambda: (session_mock, "mock_client")
         test_table = agate.Table(
@@ -137,6 +137,7 @@ class TestGlueAdapter(unittest.TestCase):
         csv_chunks = [{"test_column_double": "1.2345", "test_column_str": "test"}]
         model = {
             "name": "mock_model",
+            "alias": "mock_model",
             "schema": "mock_schema",
             "config": {"column_types": {"test_column_double": "double", "test_column_str": "string"}},
         }
@@ -157,10 +158,21 @@ class TestGlueAdapter(unittest.TestCase):
         config.credentials.enable_spark_seed_casting = False
         adapter = GlueAdapter(config, get_context("spawn"))
         csv_chunks = [{"test_column": "1.2345"}]
-        model = {"name": "mock_model", "schema": "mock_schema"}
+        model = {"name": "mock_model", "alias": "mock_model", "schema": "mock_schema"}
         column_mappings = [ColumnCsvMappingStrategy("test_column", agate.data_types.Text, "double")]
         code = adapter._map_csv_chunks_to_code(csv_chunks, config, model, "True", column_mappings)
         self.assertIn("spark.createDataFrame(csv)", code[0])
+
+    def test_create_csv_table_uses_alias_for_table_name(self):
+        config = self._get_config()
+        config.credentials.enable_spark_seed_casting = False
+        adapter = GlueAdapter(config, get_context("spawn"))
+        csv_chunks = [{"test_column": "1.2345"}]
+        model = {"name": "seed_location", "alias": "location", "schema": "mock_schema"}
+        column_mappings = [ColumnCsvMappingStrategy("test_column", agate.data_types.Text, "double")]
+        code = adapter._map_csv_chunks_to_code(csv_chunks, config, model, "True", column_mappings)
+        self.assertIn("mock_schema.location", code[0])
+        self.assertNotIn("seed_location", code[0])
 
     @mock_aws
     def test_when_database_not_exists_list_relations_without_caching_returns_empty_array(self):


### PR DESCRIPTION
resolves #535

### Description

The `alias` configuration for seeds was not being respected. When a seed had `alias: location` configured, the table was still created with the original seed name (e.g., `seed_location`) instead of the alias (`location`).

The root cause was in `_map_csv_chunks_to_code` in `impl.py`, where `model["name"]` was used to build the table name, table existence check, S3 path, and verification query. This has been changed to `model["alias"]`, which is the correct field for determining the table name in dbt. When no alias is configured, dbt automatically sets `alias` equal to `name`, so this change is backward compatible.

Changes
- `dbt/adapters/glue/impl.py`: Replace `model["name"]` with `model["alias"]` in 4 places within `_map_csv_chunks_to_code`
- `tests/unit/test_adapter.py`: Add `"alias"` key to existing test model dicts, and add a new test `test_create_csv_table_uses_alias_for_table_name` that verifies the alias is used instead of the name

Tested with unit tests (51 passed) and verified on a live AWS Glue environment that the seed table is created with the alias name.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.