### PR TITLE
Preserve Iceberg column order on schema change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed `ref()` and `source()` in Python models to use dbt-core's resolved functions
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
+- Preserve column order when adding columns to Iceberg tables via `on_schema_change`
 
 ## 1.10.19
 

--- a/dbt/include/glue/macros/adapters.sql
+++ b/dbt/include/glue/macros/adapters.sql
@@ -12,6 +12,82 @@
   {%- endif %}
 {%- endmacro -%}
 
+{% macro glue__process_schema_changes_with_column_order(on_schema_change, source_relation, target_relation, file_format) %}
+  {%- set is_iceberg = file_format in ['iceberg', 's3tables'] -%}
+
+  {%- if not is_iceberg -%}
+    {%- do process_schema_changes(on_schema_change, source_relation, target_relation) -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- if on_schema_change == 'ignore' -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}
+  {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}
+  {%- set target_names = target_columns | map(attribute='name') | list -%}
+  {%- set add_columns = [] -%}
+  {%- for sc in source_columns -%}
+    {%- if sc.name not in target_names -%}
+      {%- do add_columns.append(sc) -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- set new_target_types = diff_column_data_types(source_columns, target_columns) -%}
+
+  {%- if add_columns | length == 0 and new_target_types | length == 0 -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- if on_schema_change == 'fail' -%}
+    {% set target_not_in_source = [] %}
+    {%- set source_names = source_columns | map(attribute='name') | list -%}
+    {%- for tc in target_columns -%}
+      {%- if tc.name not in source_names -%}
+        {%- do target_not_in_source.append(tc) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if add_columns | length > 0 or target_not_in_source | length > 0 or new_target_types | length > 0 -%}
+      {{ exceptions.raise_compiler_error("The source and target schemas on this incremental model are out of sync!") }}
+    {%- endif -%}
+  {%- endif -%}
+
+  {# Add columns with position for Iceberg #}
+  {%- if add_columns | length > 0 -%}
+    {%- set full_relation = glue__make_target_relation(target_relation, file_format) -%}
+
+    {%- for col in add_columns -%}
+      {%- set ns = namespace(after_col=none, found=false) -%}
+      {%- for sc in source_columns -%}
+        {%- if not ns.found -%}
+          {%- if sc.name == col.name -%}
+            {%- set ns.found = true -%}
+          {%- else -%}
+            {%- set ns.after_col = sc.name -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+
+      {%- call statement('add_column_' ~ loop.index) -%}
+        alter table {{ full_relation }} add column {{ col.name }} {{ col.data_type }}
+        {%- if ns.after_col %} after {{ ns.after_col }}
+        {%- else %} first
+        {%- endif -%}
+      {%- endcall -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {# Type changes #}
+  {%- if on_schema_change == 'sync_all_columns' and new_target_types | length > 0 -%}
+    {%- for ntt in new_target_types -%}
+      {%- do alter_column_type(target_relation, ntt['column_name'], ntt['new_type']) -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+{% endmacro %}
+
+
 {% macro spark__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
 
   {% if remove_columns %}

--- a/dbt/include/glue/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/incremental.sql
@@ -73,7 +73,7 @@
             {{ create_temporary_view(tmp_relation, add_iceberg_timestamp_column(sql)) }}
           {%- endcall -%}
           {%- set is_tmp_relation_created = 'True' -%} 
-          {%- do process_schema_changes(on_schema_change, tmp_relation, target_relation) -%}
+          {%- set schema_changes = glue__process_schema_changes_with_column_order(on_schema_change, tmp_relation, target_relation, file_format) -%}
 
           {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
           {% set build_sql = dbt_glue_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, incremental_predicates, dest_columns) %}

--- a/tests/functional/adapter/test_iceberg.py
+++ b/tests/functional/adapter/test_iceberg.py
@@ -365,6 +365,93 @@ select * from glue_catalog.{{ ref('base_model') }}
         assert "phone" in updated_columns, "Schema change should add the phone column"
 
 
+class TestIcebergColumnOrderOnSchemaChange:
+    """Test that column order is preserved when adding columns to Iceberg tables"""
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "iceberg_column_order_test",
+            "models": {
+                "+file_format": "iceberg",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "col_order_model.sql": """
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        file_format='iceberg',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+select 1 as id, 100 as amount, 'alice' as name
+            """
+        }
+
+    def test_column_order_preserved(self, project):
+        # 1st run: create table with (id, amount, name)
+        results = run_dbt(["run", "--select", "col_order_model"])
+        assert len(results) == 1
+
+        relation = relation_from_name(project.adapter, "col_order_model")
+        initial_columns = [c.name for c in project.adapter.get_columns_in_relation(relation)]
+        assert initial_columns == ["id", "amount", "name"]
+
+        # 2nd run: add category between id and amount
+        write_file("""
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        file_format='iceberg',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+select 2 as id, 'electronics' as category, 200 as amount, 'bob' as name
+            """,
+            project.project_root, "models", "col_order_model.sql"
+        )
+
+        results = run_dbt(["run", "--select", "col_order_model"])
+        assert len(results) == 1
+
+        relation = relation_from_name(project.adapter, "col_order_model")
+        updated_columns = [c.name for c in project.adapter.get_columns_in_relation(relation)]
+        assert updated_columns == ["id", "category", "amount", "name"], \
+            f"Expected column order [id, category, amount, name] but got {updated_columns}"
+
+        # 3rd run: add two more columns at different positions
+        write_file("""
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append',
+        file_format='iceberg',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+select 3 as id, 'electronics' as category, 'premium' as tier, 300 as amount, 'charlie' as name, 'us' as region
+            """,
+            project.project_root, "models", "col_order_model.sql"
+        )
+
+        results = run_dbt(["run", "--select", "col_order_model"])
+        assert len(results) == 1
+
+        relation = relation_from_name(project.adapter, "col_order_model")
+        final_columns = [c.name for c in project.adapter.get_columns_in_relation(relation)]
+        assert final_columns == ["id", "category", "tier", "amount", "name", "region"], \
+            f"Expected column order [id, category, tier, amount, name, region] but got {final_columns}"
+
+
 class TestIcebergTimestampColumnEnabled:
     """Test adding update_iceberg_ts column to Iceberg tables when enabled"""
 


### PR DESCRIPTION
resolves #531

### Description

When columns are added to an Iceberg table via `on_schema_change='sync_all_columns'` or `'append_new_columns'`, they are currently always appended to the end of the table regardless of their position in the source model. This PR preserves the source column order by using `ALTER TABLE ADD COLUMN ... AFTER` instead of `ALTER TABLE ADD COLUMNS`.

For Iceberg/S3Tables incremental models, a new macro `glue__process_schema_changes_with_column_order` replaces the call to `process_schema_changes` in the incremental materialization. It walks the source column list to determine the correct position for each new column and issues individual `ALTER TABLE ADD COLUMN col type AFTER prev_col` (or `FIRST`) statements. Non-Iceberg models fall back to the existing `process_schema_changes` behavior.

Changes:
- `dbt/include/glue/macros/adapters.sql`: Add `glue__process_schema_changes_with_column_order` macro
- `dbt/include/glue/macros/materializations/incremental/incremental.sql`: Call the new macro for Iceberg schema changes
- `tests/functional/adapter/test_iceberg.py`: Add `TestIcebergColumnOrderOnSchemaChange` with single and multi-column addition test cases

Verified on a live AWS Glue environment that columns are inserted at the correct positions.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.