### PR TITLE
feat: wire use_interactive_session_role_for_api_calls to session management client

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The table below describes all the options.
 | group_session_id                      | [**Model Level Meta Setting**] Set a specific glue session suffix id to group sets of models together to a specific session id.  Good for models that have chained dependencies in a larger dag and you want to save on session startup times.                                      | no        | 
 | datalake_formats	                       | The ACID datalake format that you want to use if you are doing merge, can be `hudi`, `iceberg` or `delta`                                                                                                                                                                                         |no|
 | use_arrow	                           | (experimental) use an arrow file instead of stdout to have better scalability.                                                                                                                                                                                                                    |no|
+| use_interactive_session_role_for_api_calls | When `true`, the client principal assumes `role_arn` via STS before making any Glue API calls (session management and DDL operations). Required for cross-account scenarios where the caller resides in a different AWS account than the Glue resources. Default `False`. | no |
 | enable_spark_seed_casting	              | Allows spark to cast the columns depending on the specified model column types. Default `False`.        |no|
 
 ## Configs

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -275,8 +275,25 @@ class GlueConnection:
         if not self._client:
             # reference on why lock is required - https://stackoverflow.com/a/61943955/6034432
             with self._boto3_client_lock:
-                session = boto3.session.Session()
-                self._client = session.client("glue", region_name=self.credentials.region, config=config)
+                if self.credentials.role_arn and self.credentials.use_interactive_session_role_for_api_calls:
+                    logger.debug(f"Assuming role {self.credentials.role_arn} for Glue API calls")
+                    sts_client = boto3.client('sts', region_name=self.credentials.region)
+                    assumed_role = sts_client.assume_role(
+                        RoleArn=self.credentials.role_arn,
+                        RoleSessionName="dbt-glue-session"
+                    )
+                    assumed_credentials = assumed_role['Credentials']
+                    self._client = boto3.client(
+                        "glue",
+                        region_name=self.credentials.region,
+                        config=config,
+                        aws_access_key_id=assumed_credentials['AccessKeyId'],
+                        aws_secret_access_key=assumed_credentials['SecretAccessKey'],
+                        aws_session_token=assumed_credentials['SessionToken'],
+                    )
+                else:
+                    session = boto3.session.Session()
+                    self._client = session.client("glue", region_name=self.credentials.region, config=config)
                 self._session_waiter = get_session_waiter(client=self._client, timeout=self.credentials.session_provisioning_timeout_in_seconds)
         return self._client
 

--- a/tests/unit/gluedbapi/test_connection.py
+++ b/tests/unit/gluedbapi/test_connection.py
@@ -36,3 +36,43 @@ class TestGlueConnection(unittest.TestCase):
         retries = kwargs["config"].retries
         assert retries["max_attempts"] == 4
         assert retries["mode"] == "standard"
+
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.get_session_waiter")
+    @mock.patch("dbt.adapters.glue.gluedbapi.connection.boto3")
+    def test_client_assumes_role_when_flag_enabled(self, mock_boto3, mock_waiter) -> None:
+        mock_waiter.return_value = mock.Mock()
+        mock_sts_client = mock.Mock()
+        mock_glue_client = mock.Mock()
+        mock_boto3.client.side_effect = lambda service, **kwargs: (
+            mock_sts_client if service == "sts" else mock_glue_client
+        )
+        mock_sts_client.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "AKIA_ASSUMED",
+                "SecretAccessKey": "secret_assumed",
+                "SessionToken": "token_assumed",
+            }
+        }
+
+        credentials = GlueCredentials(
+            role_arn="arn:aws:iam::123456789012:role/MyRole",
+            region="us-east-1",
+            use_interactive_session_role_for_api_calls=True,
+        )
+
+        connection = GlueConnection(credentials)
+        client = connection.client
+
+        assert client is mock_glue_client
+        mock_boto3.client.assert_any_call("sts", region_name="us-east-1")
+        mock_sts_client.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/MyRole",
+            RoleSessionName="dbt-glue-session",
+        )
+        _, glue_kwargs = [
+            call for call in mock_boto3.client.call_args_list if call[0][0] == "glue"
+        ][-1]
+        assert glue_kwargs["aws_access_key_id"] == "AKIA_ASSUMED"
+        assert glue_kwargs["aws_secret_access_key"] == "secret_assumed"
+        assert glue_kwargs["aws_session_token"] == "token_assumed"
+        assert glue_kwargs["region_name"] == "us-east-1"


### PR DESCRIPTION
## Summary

This PR completes the implementation of the existing `use_interactive_session_role_for_api_calls` credential flag for the interactive session management layer.

### Background: AWS Glue Interactive Sessions security model

Glue Interactive Sessions uses a two-principal model ([docs](https://docs.aws.amazon.com/glue/latest/dg/glue-is-security.html)):

- **Client principal** — the IAM identity running dbt. Makes Glue API calls (`CreateSession`, `RunStatement`, etc.). Requires `glue:*` + `iam:PassRole` to the runtime role.
- **Runtime role** (`role_arn`) — passed to `CreateSession`. AWS Glue itself assumes this to execute Spark. Requires S3, CloudWatch, etc.

In cross-account scenarios (client principal in account A, Glue resources in account B), the client principal must first assume `role_arn` via STS before it can make any Glue API calls.

### The bug

`use_interactive_session_role_for_api_calls` was already wired in `impl.py::get_connection()` to assume the role before making Glue **management API calls** (DDL, schema operations). However, `GlueConnection.client` — the boto3 client used for **session lifecycle** (`CreateSession`, `GetSession`, `StopSession`, `DeleteSession`) — never applied the same logic. This meant cross-account users would fail at session creation even with the flag enabled.

### Changes

- **`dbt/adapters/glue/gluedbapi/connection.py`**: In the `client` property, add a branch that assumes `role_arn` via STS when `use_interactive_session_role_for_api_calls=True`, then uses the assumed credentials to create the Glue boto3 client for session management.
- **`tests/unit/gluedbapi/test_connection.py`**: Add `test_client_assumes_role_when_flag_enabled` to verify the STS assume-role path is taken and assumed credentials are passed to the Glue client.
- **`README.md`**: Document `use_interactive_session_role_for_api_calls` in the profiles config table (it was present in `credentials.py` but missing from docs).

### Note on impl.py inconsistency

`impl.py::get_connection()` has a minor inconsistency vs. this implementation: it does not pass `region_name` to the STS client and uses `RoleSessionName="dbt"`. This PR uses the more correct form (`region_name` forwarded, `RoleSessionName="dbt-glue-session"`). Aligning `impl.py` is left as a separate concern.

## Test plan

- [ ] `test_client_assumes_role_when_flag_enabled` passes — verifies STS `assume_role` is called with correct `RoleArn` and `RoleSessionName`, and assumed credentials are forwarded to the Glue client
- [ ] `test_client_uses_credentials_retry_settings` still passes — verifies default (non-assume-role) path is unchanged
- [ ] Manual cross-account dbt run with `use_interactive_session_role_for_api_calls: true` in `profiles.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)