### PR TITLE
feat: fix glue catalog quotes when setting quoting config to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed `ref()` and `source()` in Python models to use dbt-core's resolved functions
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
 - Fixed incorrect error response assumption in Glue statement output. The `Status` field from `Statement.Output` should only return lowercase `ok` or `error`. The previous check `output.get('Status') == 'ERROR'` would miss non-uppercase, causing errors to silently pass as successful executions.
+- Fixed incorrect behaviour where dbt-glue adapter does not quote the schema and identifier when config is set.
 
 ## 1.10.19
 

--- a/dbt/adapters/glue/impl.py
+++ b/dbt/adapters/glue/impl.py
@@ -62,7 +62,6 @@ class ColumnCsvMappingStrategy:
             )
             for i, column in enumerate(agate_table.columns)
         ]
-    
 class GlueAdapter(SQLAdapter):
     ConnectionManager = GlueConnectionManager
     Relation = SparkRelation
@@ -157,6 +156,7 @@ class GlueAdapter(SQLAdapter):
                         schema=schema_relation.schema,
                         identifier=table.get("Name"),
                         type=self.relation_type_map.get(table.get("TableType")),
+                        quote_policy=schema_relation.quote_policy,
                     ))
             return relations
         except client.exceptions.EntityNotFoundException as e:
@@ -239,7 +239,8 @@ class GlueAdapter(SQLAdapter):
                         database=computed_schema,
                         schema=computed_schema,
                         identifier=identifier,
-                        type='table'
+                        type='table',
+                        quote_policy=self.config.quoting,
                     )
                 except Exception as e:
                     return None
@@ -261,7 +262,8 @@ class GlueAdapter(SQLAdapter):
                 schema=computed_schema,
                 identifier=identifier,
                 type=self.relation_type_map.get(response.get("Table", {}).get("TableType", "Table")),
-                is_delta=is_delta
+                is_delta=is_delta,
+                quote_policy=self.config.quoting,
             )
             logger.debug(f"""schema : {schema}
                              identifier : {identifier}
@@ -275,7 +277,7 @@ class GlueAdapter(SQLAdapter):
 
     def __compute_schema_based_on_type(self, schema, identifier):
         iceberg_catalog = self.get_custom_iceberg_catalog_namespace()
-        current_relation = self.Relation.create(database=schema, schema=schema, identifier=identifier)
+        current_relation = self.Relation.create(database=schema, schema=schema, identifier=identifier, quote_policy=self.config.quoting)
         existing_relation_type = self.get_table_type(current_relation)
         already_exist_iceberg = (existing_relation_type == 'iceberg_table')
         non_null_catalog = (iceberg_catalog is not None)

--- a/dbt/adapters/glue/relation.py
+++ b/dbt/adapters/glue/relation.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Type, Any
 from dataclasses import dataclass, field
 from dbt.adapters.base.relation import BaseRelation, Policy
 from dbt_common.exceptions import DbtRuntimeError

--- a/dbt/adapters/glue/relation.py
+++ b/dbt/adapters/glue/relation.py
@@ -27,6 +27,27 @@ class SparkRelation(BaseRelation):
     is_hudi: Optional[bool] = None
     information: str = None
 
+    @classmethod
+    def create_from(
+        cls: Type['SparkRelation'],
+        quoting,
+        relation_config,
+        **kwargs: Any,
+    ) -> 'SparkRelation':
+        # Override quoting defaults because dbt core will deep_merge `None` values over True
+        rel = super().create_from(quoting, relation_config, **kwargs)
+        
+        # Force default true for quote_policy if not explicitly disabled in project
+        quote_policy = rel.quote_policy
+        if getattr(quote_policy, 'database', None) is None:
+            quote_policy.database = True
+        if getattr(quote_policy, 'schema', None) is None:
+            quote_policy.schema = True
+        if getattr(quote_policy, 'identifier', None) is None:
+            quote_policy.identifier = True
+            
+        return rel
+
     def __post_init__(self):
         return
         if self.database != self.schema and self.database:

--- a/dbt/adapters/glue/relation.py
+++ b/dbt/adapters/glue/relation.py
@@ -2,6 +2,7 @@ from typing import Optional, Type, Any
 from dataclasses import dataclass, field
 from dbt.adapters.base.relation import BaseRelation, Policy
 from dbt_common.exceptions import DbtRuntimeError
+from dbt_common.utils import deep_merge
 
 
 @dataclass
@@ -34,19 +35,36 @@ class SparkRelation(BaseRelation):
         relation_config,
         **kwargs: Any,
     ) -> 'SparkRelation':
-        # Override quoting defaults because dbt core will deep_merge `None` values over True
-        rel = super().create_from(quoting, relation_config, **kwargs)
-        
-        # Force default true for quote_policy if not explicitly disabled in project
-        quote_policy = rel.quote_policy
-        if getattr(quote_policy, 'database', None) is None:
-            quote_policy.database = True
-        if getattr(quote_policy, 'schema', None) is None:
-            quote_policy.schema = True
-        if getattr(quote_policy, 'identifier', None) is None:
-            quote_policy.identifier = True
-            
-        return rel
+        # If unset (None), it defaults to False. If explicitly set, that value is inherited.
+        def _drop_none(policy_dict):
+            return {k: v for k, v in (policy_dict or {}).items() if v is not None}
+
+        quote_policy = _drop_none(kwargs.pop('quote_policy', {}))
+
+        config_quoting = dict(relation_config.quoting_dict)
+        config_quoting.pop('column', None)
+
+        catalog_name = (
+            relation_config.catalog_name
+            if hasattr(relation_config, 'catalog_name')
+            else relation_config.config.get('catalog', None)
+        )
+
+        merged_quote_policy = deep_merge(
+            cls.get_default_quote_policy().to_dict(omit_none=True),
+            _drop_none(quoting.quoting),
+            _drop_none(config_quoting),
+            quote_policy,
+        )
+
+        return cls.create(
+            database=relation_config.database,
+            schema=relation_config.schema,
+            identifier=relation_config.identifier,
+            quote_policy=merged_quote_policy,
+            catalog_name=catalog_name,
+            **kwargs,
+        )
 
     def __post_init__(self):
         return

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -190,6 +190,7 @@ class TestGlueAdapter(unittest.TestCase):
         adapter.get_connection = lambda : (None, glue_client)
         relation = Mock(SparkRelation)
         relation.schema = database_name
+        relation.quote_policy = SparkRelation.get_default_quote_policy()
 
         relations = adapter.list_relations_without_caching(relation)
 

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock
 
 from dbt.adapters.glue.relation import SparkRelation
 from dbt.exceptions import DbtRuntimeError
@@ -102,3 +103,100 @@ class TestGlueRelation(unittest.TestCase):
         relation = SparkRelation.from_dict(data)
         with self.assertRaises(DbtRuntimeError):
             relation.render()
+
+
+class TestSparkRelationCreateFrom(unittest.TestCase):
+    def _make_quoting(self, quoting_dict):
+        quoting = Mock()
+        quoting.quoting = quoting_dict
+        return quoting
+
+    def _make_relation_config(self, quoting_dict=None):
+        relation_config = Mock()
+        relation_config.quoting_dict = quoting_dict if quoting_dict is not None else {}
+        relation_config.database = "my_db"
+        relation_config.schema = "my_schema"
+        relation_config.identifier = "my_table"
+        relation_config.catalog_name = None
+        return relation_config
+
+    def test_none_quoting_in_project_defaults_to_true(self):
+        """When dbt core deep_merges None values into the quote policy, they should default to True."""
+        quoting = self._make_quoting({"database": None, "schema": None, "identifier": None})
+        relation_config = self._make_relation_config()
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertTrue(rel.quote_policy.database)
+        self.assertTrue(rel.quote_policy.schema)
+        self.assertTrue(rel.quote_policy.identifier)
+
+    def test_explicit_false_quoting_is_preserved(self):
+        """When quoting is explicitly set to False in the project, it should not be overridden."""
+        quoting = self._make_quoting({"database": False, "schema": False, "identifier": False})
+        relation_config = self._make_relation_config()
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertFalse(rel.quote_policy.database)
+        self.assertFalse(rel.quote_policy.schema)
+        self.assertFalse(rel.quote_policy.identifier)
+
+    def test_explicit_true_quoting_is_preserved(self):
+        """When quoting is explicitly set to True in the project, it should remain True."""
+        quoting = self._make_quoting({"database": True, "schema": True, "identifier": True})
+        relation_config = self._make_relation_config()
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertTrue(rel.quote_policy.database)
+        self.assertTrue(rel.quote_policy.schema)
+        self.assertTrue(rel.quote_policy.identifier)
+
+    def test_mixed_none_and_explicit_quoting(self):
+        """None fields default to True while explicitly set fields are preserved."""
+        quoting = self._make_quoting({"database": None, "schema": False, "identifier": True})
+        relation_config = self._make_relation_config()
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertTrue(rel.quote_policy.database)   # None → defaulted to True
+        self.assertFalse(rel.quote_policy.schema)    # explicitly False → preserved
+        self.assertTrue(rel.quote_policy.identifier) # explicitly True → preserved
+
+    def test_none_quoting_in_config_defaults_to_true(self):
+        """When relation_config.quoting_dict contains None values, they should default to True."""
+        quoting = self._make_quoting({})
+        relation_config = self._make_relation_config(
+            quoting_dict={"database": None, "schema": None, "identifier": None}
+        )
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertTrue(rel.quote_policy.database)
+        self.assertTrue(rel.quote_policy.schema)
+        self.assertTrue(rel.quote_policy.identifier)
+
+    def test_explicit_false_in_config_is_preserved(self):
+        """When relation_config.quoting_dict explicitly sets False, it should not be overridden."""
+        quoting = self._make_quoting({})
+        relation_config = self._make_relation_config(
+            quoting_dict={"database": False, "schema": False, "identifier": False}
+        )
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertFalse(rel.quote_policy.database)
+        self.assertFalse(rel.quote_policy.schema)
+        self.assertFalse(rel.quote_policy.identifier)
+
+    def test_relation_path_is_set_correctly(self):
+        """Ensures create_from correctly passes through database/schema/identifier."""
+        quoting = self._make_quoting({})
+        relation_config = self._make_relation_config()
+
+        rel = SparkRelation.create_from(quoting, relation_config)
+
+        self.assertEqual(rel.database, "my_db")
+        self.assertEqual(rel.schema, "my_schema")
+        self.assertEqual(rel.identifier, "my_table")

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -120,16 +120,16 @@ class TestSparkRelationCreateFrom(unittest.TestCase):
         relation_config.catalog_name = None
         return relation_config
 
-    def test_none_quoting_in_project_defaults_to_true(self):
-        """When dbt core deep_merges None values into the quote policy, they should default to True."""
+    def test_none_quoting_in_project_falls_back_to_adapter_default(self):
+        """When quoting is unset (None) in the project, it should fall back to the adapter default (False)."""
         quoting = self._make_quoting({"database": None, "schema": None, "identifier": None})
         relation_config = self._make_relation_config()
 
         rel = SparkRelation.create_from(quoting, relation_config)
 
-        self.assertTrue(rel.quote_policy.database)
-        self.assertTrue(rel.quote_policy.schema)
-        self.assertTrue(rel.quote_policy.identifier)
+        self.assertFalse(rel.quote_policy.database)
+        self.assertFalse(rel.quote_policy.schema)
+        self.assertFalse(rel.quote_policy.identifier)
 
     def test_explicit_false_quoting_is_preserved(self):
         """When quoting is explicitly set to False in the project, it should not be overridden."""
@@ -154,18 +154,18 @@ class TestSparkRelationCreateFrom(unittest.TestCase):
         self.assertTrue(rel.quote_policy.identifier)
 
     def test_mixed_none_and_explicit_quoting(self):
-        """None fields default to True while explicitly set fields are preserved."""
+        """Unset (None) fields fall back to the adapter default while explicitly set fields are preserved."""
         quoting = self._make_quoting({"database": None, "schema": False, "identifier": True})
         relation_config = self._make_relation_config()
 
         rel = SparkRelation.create_from(quoting, relation_config)
 
-        self.assertTrue(rel.quote_policy.database)   # None → defaulted to True
+        self.assertFalse(rel.quote_policy.database)  # None → falls back to adapter default (False)
         self.assertFalse(rel.quote_policy.schema)    # explicitly False → preserved
         self.assertTrue(rel.quote_policy.identifier) # explicitly True → preserved
 
-    def test_none_quoting_in_config_defaults_to_true(self):
-        """When relation_config.quoting_dict contains None values, they should default to True."""
+    def test_none_quoting_in_config_falls_back_to_adapter_default(self):
+        """When relation_config.quoting_dict contains None values, they should fall back to the adapter default (False)."""
         quoting = self._make_quoting({})
         relation_config = self._make_relation_config(
             quoting_dict={"database": None, "schema": None, "identifier": None}
@@ -173,9 +173,9 @@ class TestSparkRelationCreateFrom(unittest.TestCase):
 
         rel = SparkRelation.create_from(quoting, relation_config)
 
-        self.assertTrue(rel.quote_policy.database)
-        self.assertTrue(rel.quote_policy.schema)
-        self.assertTrue(rel.quote_policy.identifier)
+        self.assertFalse(rel.quote_policy.database)
+        self.assertFalse(rel.quote_policy.schema)
+        self.assertFalse(rel.quote_policy.identifier)
 
     def test_explicit_false_in_config_is_preserved(self):
         """When relation_config.quoting_dict explicitly sets False, it should not be overridden."""


### PR DESCRIPTION
resolves #675

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

This PR resolves the issue where quoting configuration does not flow through for the glue statement during table materialization.

For example
```
Exception: 
  [INVALID_IDENTIFIER] The identifier glue-schema is invalid. Please, consider quoting it with back-quotes as `glue-schema`.(line 3, pos 29)
  
  == SQL ==
  /* {"app": "dbt", "dbt_version": "1.10.20", "profile_name": "glue_ecommerce", "target_name": "dev", "node_id": "model.glue_ecommerce.stg_customers"} */
  
      drop table if exists glue-schema.stg_customers
  -----------------------------^^^
  
15:27:09  
15:27:09    compiled code at target/compiled/glue_ecommerce/models/staging/stg_customers.sql
15:27:09  
15:27:09  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 NO-OP=0 TOTAL=1
```

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.