### PR TITLE
fix: Hanging session after python model is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
 - Fixed incorrect error response assumption in Glue statement output. The `Status` field from `Statement.Output` should only return lowercase `ok` or `error`. The previous check `output.get('Status') == 'ERROR'` would miss non-uppercase, causing errors to silently pass as successful executions.
 - Fixed incremental append and partition_by support for Iceberg Python
+- Fixed hanging Glue session after a Python model completes. The session is now closed in a `finally` block after Python model execution (success or failure), unless `glue_session_reuse: true` is set, in which case `close_session()` returns early and leaves the session running.
 
 ## 1.10.19
 

--- a/dbt/adapters/glue/python_submissions.py
+++ b/dbt/adapters/glue/python_submissions.py
@@ -5,8 +5,10 @@ from typing import Any, Dict
 
 from dbt.adapters.base import PythonJobHelper
 from dbt_common.exceptions import DbtRuntimeError
+from dbt.adapters.events.logging import AdapterLogger
 
 from dbt.adapters.glue import GlueCredentials
+
 
 class GluePythonJobHelper(PythonJobHelper):
     def __init__(self, parsed_model: Dict, credentials: GlueCredentials) -> None:
@@ -41,12 +43,17 @@ class GluePythonJobHelper(PythonJobHelper):
         try:
             # Run the actual Python code
             statement_id = self._run_statement(glue_client, session_id, compiled_code)
-            
+
             # Wait for completion
             self._wait_for_statement_completion(glue_client, session_id, statement_id)
-            
+
         except Exception as e:
             raise DbtRuntimeError(f"Python model execution failed: {str(e)}")
+        finally:
+            # Close the session unless glue_session_reuse is enabled.
+            # close_session() already honors glue_session_reuse and returns
+            # early without stopping the session when reuse is requested.
+            connection.close_session()
     
     def _run_statement(self, glue_client, session_id, code):
         """Run a Python statement in the existing Glue session"""
@@ -55,7 +62,7 @@ class GluePythonJobHelper(PythonJobHelper):
             Code=code
         )
         return response['Id']
-    
+
     def _wait_for_statement_completion(self, glue_client, session_id, statement_id):
         """Wait for a statement to complete execution"""
         start_time = time.time()

--- a/dbt/adapters/glue/python_submissions.py
+++ b/dbt/adapters/glue/python_submissions.py
@@ -5,8 +5,6 @@ from typing import Any, Dict
 
 from dbt.adapters.base import PythonJobHelper
 from dbt_common.exceptions import DbtRuntimeError
-from dbt.adapters.events.logging import AdapterLogger
-
 from dbt.adapters.glue import GlueCredentials
 
 

--- a/dbt/adapters/glue/python_submissions.py
+++ b/dbt/adapters/glue/python_submissions.py
@@ -38,8 +38,6 @@ class GluePythonJobHelper(PythonJobHelper):
         glue_client = connection.client
         session_id = connection.session_id
         
-        print(f"DEBUG: Using Glue session: {session_id}")
-        
         try:
             # Run the actual Python code
             statement_id = self._run_statement(glue_client, session_id, compiled_code)


### PR DESCRIPTION
resolves #664

### Description

After successful or failed build of a python dbt model the session still hangs despite not having glue_session_reuse: true

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.