### PR TITLE
fix: running two models at exact same moment with reusable_session set to true causes `AlreadyExistsException` error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
 - Fixed incorrect error response assumption in Glue statement output. The `Status` field from `Statement.Output` should only return lowercase `ok` or `error`. The previous check `output.get('Status') == 'ERROR'` would miss non-uppercase, causing errors to silently pass as successful executions.
 - Fixed incremental append and partition_by support for Iceberg Python
+- Fixed a cross-process race when reusable sessions are enabled: starting two dbt runs at nearly the same time with the same `glue_session_id` could fail with a session creation error, because both processes created the same session id concurrently.
 
 ## 1.10.19
 

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -190,16 +190,22 @@ class GlueConnection:
         if (self.credentials.datalake_formats is not None):
             args["--datalake-formats"] = f"{self.credentials.datalake_formats}"
 
-        self._session = self.client.create_session(
-            Id=session_id,
-            Role=self._create_session_config["role_arn"],
-            DefaultArguments=args,
-            Command={
-                "Name": "glueetl",
-                "PythonVersion": "3"
-            },
-            **additional_args
-        )
+        try:
+            self._session = self.client.create_session(
+                Id=session_id,
+                Role=self._create_session_config["role_arn"],
+                DefaultArguments=args,
+                Command={
+                    "Name": "glueetl",
+                    "PythonVersion": "3"
+                },
+                **additional_args
+            )
+        except self.client.exceptions.AlreadyExistsException:
+            logger.debug(
+                f"Session {session_id} already exists, created by a concurrent process. Reusing it."
+            )
+            self._session = {"Session": {"Id": session_id}}
 
         return
 

--- a/tests/unit/gluedbapi/test_connection.py
+++ b/tests/unit/gluedbapi/test_connection.py
@@ -36,3 +36,45 @@ class TestGlueConnection(unittest.TestCase):
         retries = kwargs["config"].retries
         assert retries["max_attempts"] == 4
         assert retries["mode"] == "standard"
+
+    def test_create_session_tolerates_concurrent_already_exists(self) -> None:
+        """A concurrent dbt process may create the reusable session first.
+
+        `create_session` then raises AlreadyExistsException, which must be
+        swallowed so the caller attaches to the existing session instead of
+        failing the run.
+        """
+        connection = GlueConnection(GlueCredentials())
+
+        mock_client = mock.Mock()
+
+        class AlreadyExistsException(Exception):
+            pass
+
+        mock_client.exceptions.AlreadyExistsException = AlreadyExistsException
+        mock_client.create_session.side_effect = AlreadyExistsException("session exists")
+        connection._client = mock_client
+
+        # Should not raise, and should attach to the existing session id.
+        connection._create_session(session_id="dbt-glue")
+
+        assert connection.session_id == "dbt-glue"
+
+    def test_create_session_reraises_other_errors(self) -> None:
+        """Errors other than AlreadyExistsException must still propagate."""
+        connection = GlueConnection(GlueCredentials())
+
+        mock_client = mock.Mock()
+
+        class AlreadyExistsException(Exception):
+            pass
+
+        class InvalidInputException(Exception):
+            pass
+
+        mock_client.exceptions.AlreadyExistsException = AlreadyExistsException
+        mock_client.create_session.side_effect = InvalidInputException("bad input")
+        connection._client = mock_client
+
+        with self.assertRaises(InvalidInputException):
+            connection._create_session(session_id="dbt-glue")


### PR DESCRIPTION
### Description

running two models at exact same moment with reusable_session set to true causes `AlreadyExistsException` error.

This is mainly present when running dbt-glue on Airflow with Cosmos dbt plugin using sub-processes, that runs dbt independently. 

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.