### PR TITLE
ci: Secure fork-PR integration tests against pwn requests (TOCTOU)

### DIFF
--- a/.github/actions/check-trigger/action.yml
+++ b/.github/actions/check-trigger/action.yml
@@ -1,0 +1,92 @@
+name: Check trigger
+description: >
+  Validate a maintainer "/test glue <sha>" comment and pin the reviewed SHA.
+  Verifies the commenter has write/admin permission, that the comment pins a
+  full 40-char SHA, and that the pinned SHA still equals the PR head (blocking
+  a post-review push / TOCTOU). On success, sets a pending commit status on the
+  validated SHA and returns it as an output.
+inputs:
+  status-context:
+    description: Commit status context to report under (e.g. integration-tests).
+    required: true
+  test-name:
+    description: Human-readable test name used in comments/status (e.g. Integration tests).
+    required: true
+outputs:
+  sha:
+    description: The validated commit SHA, set only when all checks pass.
+    value: ${{ steps.validate-sha.outputs.sha }}
+runs:
+  using: composite
+  steps:
+    - id: validate-sha
+      uses: actions/github-script@v7
+      env:
+        STATUS_CONTEXT: ${{ inputs.status-context }}
+        TEST_NAME: ${{ inputs.test-name }}
+      with:
+        script: |
+          const statusContext = process.env.STATUS_CONTEXT;
+          const testName = process.env.TEST_NAME;
+
+          // 1. Commenter must have write+ permission on the repo.
+          const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
+            ...context.repo,
+            username: context.actor
+          });
+          if (!['admin', 'write'].includes(permData.permission)) {
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `❌ @${context.actor} does not have write permission on this repository.`
+            });
+            core.setFailed('Insufficient permissions');
+            return;
+          }
+
+          // 2. Comment must pin a full 40-char commit SHA.
+          const comment = context.payload.comment.body.trim();
+          const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
+          if (!shaMatch) {
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
+            });
+            core.setFailed('Invalid SHA format');
+            return;
+          }
+          const requestedSHA = shaMatch[1];
+
+          // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
+          const pr = (await github.rest.pulls.get({
+            ...context.repo,
+            pull_number: context.issue.number
+          })).data;
+          if (pr.head.sha !== requestedSHA) {
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
+            });
+            core.setFailed('SHA mismatch - possible TOCTOU');
+            return;
+          }
+
+          core.setOutput('sha', requestedSHA);
+
+          // Mark the commit pending so the result shows up as a PR check.
+          await github.rest.repos.createCommitStatus({
+            ...context.repo,
+            sha: requestedSHA,
+            context: statusContext,
+            state: 'pending',
+            target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            description: `${testName} running`
+          });
+
+          await github.rest.issues.createComment({
+            ...context.repo,
+            issue_number: context.issue.number,
+            body: `✅ ${testName} triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+          });

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,12 @@
 name: Integration Tests
 
 on:
-  # we use pull_request_target to run the CI also for forks
-  pull_request_target:
-    types: [labeled]
+  # Fork PRs run untrusted code against real AWS Glue, which requires secrets.
+  # To prevent pwn requests (TOCTOU), the test job is triggered by a maintainer
+  # comment that pins the reviewed commit SHA, and runs only if that SHA still
+  # matches the PR head. See the `check-trigger` job below.
+  issue_comment:
+    types: [created]
   push:
     branches: [main]
 
@@ -12,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'issue_comment' && github.event.issue.number || github.sha }}
   cancel-in-progress: true
 
 defaults:
@@ -20,10 +23,81 @@ defaults:
     shell: bash
 
 jobs:
-  # workflow that is invoked when for PRs with labels 'enable-functional-tests'
+  # Gate: only a maintainer comment "/test glue <40-char-sha>" can start the
+  # secret-bearing PR tests, and only if the pinned SHA still equals the PR head.
+  check-trigger:
+    name: Check trigger
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/test glue ')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    outputs:
+      pr-sha: ${{ steps.validate-sha.outputs.sha }}
+    steps:
+      - name: Validate SHA from comment
+        id: validate-sha
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // 1. Commenter must have write+ permission on the repo.
+            const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...context.repo,
+              username: context.actor
+            });
+            if (!['admin', 'write'].includes(permData.permission)) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} does not have write permission on this repository.`
+              });
+              core.setFailed('Insufficient permissions');
+              return;
+            }
+
+            // 2. Comment must pin a full 40-char commit SHA.
+            const comment = context.payload.comment.body.trim();
+            const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
+            if (!shaMatch) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
+              });
+              core.setFailed('Invalid SHA format');
+              return;
+            }
+            const requestedSHA = shaMatch[1];
+
+            // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
+            const pr = (await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number
+            })).data;
+            if (pr.head.sha !== requestedSHA) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
+              });
+              core.setFailed('SHA mismatch - possible TOCTOU');
+              return;
+            }
+
+            core.setOutput('sha', requestedSHA);
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `✅ Integration tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            });
+
+  # PR tests: run only after check-trigger has verified the commenter and SHA.
   functional-tests-pr:
     name: Functional Tests - PR / python ${{ matrix.python-version }}
-    if: contains(github.event.pull_request.labels.*.name, 'enable-functional-tests')
+    needs: check-trigger
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -43,6 +117,10 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
+        with:
+          # Only the SHA validated by check-trigger; never the live PR head.
+          ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      statuses: write
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
@@ -88,6 +89,17 @@ jobs:
             }
 
             core.setOutput('sha', requestedSHA);
+
+            // Mark the commit pending so the result shows up as a PR check.
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: requestedSHA,
+              context: 'integration-tests',
+              state: 'pending',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'Integration tests running'
+            });
+
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
@@ -166,6 +178,30 @@ jobs:
           name: integ_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: integ_results.csv
           overwrite: true
+
+  # Report the test outcome back to the validated commit so it appears as a PR
+  # check and can be made a required check via branch protection.
+  report-status:
+    name: Report integration-tests status
+    needs: [check-trigger, functional-tests-pr]
+    if: always() && needs.check-trigger.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ needs.functional-tests-pr.result }}';
+            const state = result === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: '${{ needs.check-trigger.outputs.pr-sha }}',
+              context: 'integration-tests',
+              state,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: `Integration tests ${result}`
+            });
 
   # workflow that is invoked when a push to main happens
   functional-tests-main:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
       - name: Check out the gate action from the default branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Validate SHA from comment
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Only the SHA validated by check-trigger; never the live PR head.
           ref: ${{ needs.check-trigger.outputs.pr-sha }}
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,78 +33,21 @@ jobs:
       startsWith(github.event.comment.body, '/test glue ')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       issues: write
       statuses: write
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
+      - name: Check out the gate action from the default branch
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Validate SHA from comment
         id: validate-sha
-        uses: actions/github-script@v7
+        uses: ./.github/actions/check-trigger
         with:
-          script: |
-            // 1. Commenter must have write+ permission on the repo.
-            const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
-              ...context.repo,
-              username: context.actor
-            });
-            if (!['admin', 'write'].includes(permData.permission)) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: `❌ @${context.actor} does not have write permission on this repository.`
-              });
-              core.setFailed('Insufficient permissions');
-              return;
-            }
-
-            // 2. Comment must pin a full 40-char commit SHA.
-            const comment = context.payload.comment.body.trim();
-            const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
-            if (!shaMatch) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
-              });
-              core.setFailed('Invalid SHA format');
-              return;
-            }
-            const requestedSHA = shaMatch[1];
-
-            // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
-            const pr = (await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: context.issue.number
-            })).data;
-            if (pr.head.sha !== requestedSHA) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
-              });
-              core.setFailed('SHA mismatch - possible TOCTOU');
-              return;
-            }
-
-            core.setOutput('sha', requestedSHA);
-
-            // Mark the commit pending so the result shows up as a PR check.
-            await github.rest.repos.createCommitStatus({
-              ...context.repo,
-              sha: requestedSHA,
-              context: 'integration-tests',
-              state: 'pending',
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: 'Integration tests running'
-            });
-
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body: `✅ Integration tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
-            });
+          status-context: integration-tests
+          test-name: Integration tests
 
   # PR tests: run only after check-trigger has verified the commenter and SHA.
   functional-tests-pr:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,8 +33,8 @@ jobs:
       startsWith(github.event.comment.body, '/test glue ')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      statuses: write
+      pull-requests: write  # required to comment on the PR (issues.createComment on a PR)
+      statuses: write        # required to set the commit status
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:

--- a/.github/workflows/python-models.yml
+++ b/.github/workflows/python-models.yml
@@ -37,7 +37,7 @@ jobs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
       - name: Check out the gate action from the default branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Validate SHA from comment
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Only the SHA validated by check-trigger; never the live PR head.
           ref: ${{ needs.check-trigger.outputs.pr-sha }}

--- a/.github/workflows/python-models.yml
+++ b/.github/workflows/python-models.yml
@@ -1,15 +1,19 @@
 name: Python Model Tests
 
 on:
-  pull_request_target:
-    types: [labeled]
+  # Fork PRs run untrusted code against real AWS Glue, which requires secrets.
+  # To prevent pwn requests (TOCTOU), the test job is triggered by a maintainer
+  # comment that pins the reviewed commit SHA, and runs only if that SHA still
+  # matches the PR head. See the `check-trigger` job below.
+  issue_comment:
+    types: [created]
 
 permissions:
   id-token: write
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 defaults:
@@ -17,9 +21,81 @@ defaults:
     shell: bash
 
 jobs:
+  # Gate: only a maintainer comment "/test glue <40-char-sha>" can start the
+  # secret-bearing PR tests, and only if the pinned SHA still equals the PR head.
+  check-trigger:
+    name: Check trigger
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/test glue ')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    outputs:
+      pr-sha: ${{ steps.validate-sha.outputs.sha }}
+    steps:
+      - name: Validate SHA from comment
+        id: validate-sha
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // 1. Commenter must have write+ permission on the repo.
+            const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...context.repo,
+              username: context.actor
+            });
+            if (!['admin', 'write'].includes(permData.permission)) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} does not have write permission on this repository.`
+              });
+              core.setFailed('Insufficient permissions');
+              return;
+            }
+
+            // 2. Comment must pin a full 40-char commit SHA.
+            const comment = context.payload.comment.body.trim();
+            const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
+            if (!shaMatch) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
+              });
+              core.setFailed('Invalid SHA format');
+              return;
+            }
+            const requestedSHA = shaMatch[1];
+
+            // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
+            const pr = (await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number
+            })).data;
+            if (pr.head.sha !== requestedSHA) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
+              });
+              core.setFailed('SHA mismatch - possible TOCTOU');
+              return;
+            }
+
+            core.setOutput('sha', requestedSHA);
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `✅ Python model tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            });
+
+  # PR tests: run only after check-trigger has verified the commenter and SHA.
   python-model-tests-pr:
     name: Python Model Tests - PR / python ${{ matrix.python-version }}
-    if: contains(github.event.pull_request.labels.*.name, 'enable-functional-tests')
+    needs: check-trigger
 
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -39,6 +115,10 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
+        with:
+          # Only the SHA validated by check-trigger; never the live PR head.
+          ref: ${{ needs.check-trigger.outputs.pr-sha }}
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/python-models.yml
+++ b/.github/workflows/python-models.yml
@@ -31,8 +31,8 @@ jobs:
       startsWith(github.event.comment.body, '/test glue ')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      statuses: write
+      pull-requests: write  # required to comment on the PR (issues.createComment on a PR)
+      statuses: write        # required to set the commit status
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:

--- a/.github/workflows/python-models.yml
+++ b/.github/workflows/python-models.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      statuses: write
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
@@ -86,6 +87,17 @@ jobs:
             }
 
             core.setOutput('sha', requestedSHA);
+
+            // Mark the commit pending so the result shows up as a PR check.
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: requestedSHA,
+              context: 'python-model-tests',
+              state: 'pending',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'Python model tests running'
+            });
+
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
@@ -164,3 +176,27 @@ jobs:
           name: python_model_results_pr_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: python_model_results.csv
           overwrite: true
+
+  # Report the test outcome back to the validated commit so it appears as a PR
+  # check and can be made a required check via branch protection.
+  report-status:
+    name: Report python-model-tests status
+    needs: [check-trigger, python-model-tests-pr]
+    if: always() && needs.check-trigger.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ needs.python-model-tests-pr.result }}';
+            const state = result === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: '${{ needs.check-trigger.outputs.pr-sha }}',
+              context: 'python-model-tests',
+              state,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: `Python model tests ${result}`
+            });

--- a/.github/workflows/python-models.yml
+++ b/.github/workflows/python-models.yml
@@ -31,78 +31,21 @@ jobs:
       startsWith(github.event.comment.body, '/test glue ')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       issues: write
       statuses: write
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
+      - name: Check out the gate action from the default branch
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Validate SHA from comment
         id: validate-sha
-        uses: actions/github-script@v7
+        uses: ./.github/actions/check-trigger
         with:
-          script: |
-            // 1. Commenter must have write+ permission on the repo.
-            const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
-              ...context.repo,
-              username: context.actor
-            });
-            if (!['admin', 'write'].includes(permData.permission)) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: `❌ @${context.actor} does not have write permission on this repository.`
-              });
-              core.setFailed('Insufficient permissions');
-              return;
-            }
-
-            // 2. Comment must pin a full 40-char commit SHA.
-            const comment = context.payload.comment.body.trim();
-            const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
-            if (!shaMatch) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
-              });
-              core.setFailed('Invalid SHA format');
-              return;
-            }
-            const requestedSHA = shaMatch[1];
-
-            // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
-            const pr = (await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: context.issue.number
-            })).data;
-            if (pr.head.sha !== requestedSHA) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
-              });
-              core.setFailed('SHA mismatch - possible TOCTOU');
-              return;
-            }
-
-            core.setOutput('sha', requestedSHA);
-
-            // Mark the commit pending so the result shows up as a PR check.
-            await github.rest.repos.createCommitStatus({
-              ...context.repo,
-              sha: requestedSHA,
-              context: 'python-model-tests',
-              state: 'pending',
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: 'Python model tests running'
-            });
-
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body: `✅ Python model tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
-            });
+          status-context: python-model-tests
+          test-name: Python model tests
 
   # PR tests: run only after check-trigger has verified the commenter and SHA.
   python-model-tests-pr:

--- a/.github/workflows/s3-tables.yml
+++ b/.github/workflows/s3-tables.yml
@@ -33,78 +33,21 @@ jobs:
       startsWith(github.event.comment.body, '/test glue ')
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       issues: write
       statuses: write
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
+      - name: Check out the gate action from the default branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Validate SHA from comment
         id: validate-sha
-        uses: actions/github-script@v7
+        uses: ./.github/actions/check-trigger
         with:
-          script: |
-            // 1. Commenter must have write+ permission on the repo.
-            const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
-              ...context.repo,
-              username: context.actor
-            });
-            if (!['admin', 'write'].includes(permData.permission)) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: `❌ @${context.actor} does not have write permission on this repository.`
-              });
-              core.setFailed('Insufficient permissions');
-              return;
-            }
-
-            // 2. Comment must pin a full 40-char commit SHA.
-            const comment = context.payload.comment.body.trim();
-            const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
-            if (!shaMatch) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
-              });
-              core.setFailed('Invalid SHA format');
-              return;
-            }
-            const requestedSHA = shaMatch[1];
-
-            // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
-            const pr = (await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: context.issue.number
-            })).data;
-            if (pr.head.sha !== requestedSHA) {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
-              });
-              core.setFailed('SHA mismatch - possible TOCTOU');
-              return;
-            }
-
-            core.setOutput('sha', requestedSHA);
-
-            // Mark the commit pending so the result shows up as a PR check.
-            await github.rest.repos.createCommitStatus({
-              ...context.repo,
-              sha: requestedSHA,
-              context: 's3-tables-tests',
-              state: 'pending',
-              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: 'S3 Tables tests running'
-            });
-
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body: `✅ S3 Tables tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
-            });
+          status-context: s3-tables-tests
+          test-name: S3 Tables tests
 
   test-s3-tables:
     name: S3 Tables Tests - PR / python ${{ matrix.python-version }}

--- a/.github/workflows/s3-tables.yml
+++ b/.github/workflows/s3-tables.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      statuses: write
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:
@@ -88,6 +89,17 @@ jobs:
             }
 
             core.setOutput('sha', requestedSHA);
+
+            // Mark the commit pending so the result shows up as a PR check.
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: requestedSHA,
+              context: 's3-tables-tests',
+              state: 'pending',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'S3 Tables tests running'
+            });
+
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
@@ -155,6 +167,30 @@ jobs:
         # Cleanup any test resources if needed
         echo "Cleaning up S3 tables test resources..."
         # Add cleanup commands here if necessary
+
+  # Report the test outcome back to the validated commit so it appears as a PR
+  # check and can be made a required check via branch protection.
+  report-status:
+    name: Report s3-tables-tests status
+    needs: [check-trigger, test-s3-tables]
+    if: always() && needs.check-trigger.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ needs.test-s3-tables.result }}';
+            const state = result === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: '${{ needs.check-trigger.outputs.pr-sha }}',
+              context: 's3-tables-tests',
+              state,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: `S3 Tables tests ${result}`
+            });
 
   # workflow that is invoked when a push to main happens
   s3-tables-tests-main:

--- a/.github/workflows/s3-tables.yml
+++ b/.github/workflows/s3-tables.yml
@@ -1,8 +1,12 @@
 name: S3 Tables Integration Tests
 
 on:
-  pull_request_target:
-    types: [labeled]
+  # Fork PRs run untrusted code against real AWS Glue, which requires secrets.
+  # To prevent pwn requests (TOCTOU), the test job is triggered by a maintainer
+  # comment that pins the reviewed commit SHA, and runs only if that SHA still
+  # matches the PR head. See the `check-trigger` job below.
+  issue_comment:
+    types: [created]
   push:
     branches: [main]
 
@@ -11,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ contains(github.event_name, 'pull_request') && github.event.pull_request.head.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'issue_comment' && github.event.issue.number || github.sha }}
   cancel-in-progress: true
 
 defaults:
@@ -19,9 +23,80 @@ defaults:
     shell: bash
 
 jobs:
+  # Gate: only a maintainer comment "/test glue <40-char-sha>" can start the
+  # secret-bearing PR tests, and only if the pinned SHA still equals the PR head.
+  check-trigger:
+    name: Check trigger
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/test glue ')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    outputs:
+      pr-sha: ${{ steps.validate-sha.outputs.sha }}
+    steps:
+      - name: Validate SHA from comment
+        id: validate-sha
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // 1. Commenter must have write+ permission on the repo.
+            const { data: permData } = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...context.repo,
+              username: context.actor
+            });
+            if (!['admin', 'write'].includes(permData.permission)) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} does not have write permission on this repository.`
+              });
+              core.setFailed('Insufficient permissions');
+              return;
+            }
+
+            // 2. Comment must pin a full 40-char commit SHA.
+            const comment = context.payload.comment.body.trim();
+            const shaMatch = comment.match(/^\/test glue ([a-f0-9]{40})$/);
+            if (!shaMatch) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: '❌ Invalid format. Use: `/test glue <full-40-char-sha>`'
+              });
+              core.setFailed('Invalid SHA format');
+              return;
+            }
+            const requestedSHA = shaMatch[1];
+
+            // 3. Pinned SHA must still equal the PR head (blocks post-review push / TOCTOU).
+            const pr = (await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number
+            })).data;
+            if (pr.head.sha !== requestedSHA) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `❌ SHA mismatch!\n- Provided: \`${requestedSHA}\`\n- Current PR head: \`${pr.head.sha}\`\n\nPlease re-review the latest commit and comment \`/test glue <new-sha>\`.`
+              });
+              core.setFailed('SHA mismatch - possible TOCTOU');
+              return;
+            }
+
+            core.setOutput('sha', requestedSHA);
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `✅ S3 Tables tests triggered by @${context.actor} for \`${requestedSHA}\`. [View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+            });
+
   test-s3-tables:
     name: S3 Tables Tests - PR / python ${{ matrix.python-version }}
-    if: contains(github.event.pull_request.labels.*.name, 'enable-functional-tests')
+    needs: check-trigger
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -29,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
-    
+
     env:
       DBT_AWS_ACCOUNT: ${{ secrets.DBT_AWS_ACCOUNT }}
       DBT_GLUE_ROLE_ARN: ${{ secrets.DBT_GLUE_ROLE_ARN }}
@@ -41,6 +116,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Only the SHA validated by check-trigger; never the live PR head.
+        ref: ${{ needs.check-trigger.outputs.pr-sha }}
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/s3-tables.yml
+++ b/.github/workflows/s3-tables.yml
@@ -33,8 +33,8 @@ jobs:
       startsWith(github.event.comment.body, '/test glue ')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      statuses: write
+      pull-requests: write  # required to comment on the PR (issues.createComment on a PR)
+      statuses: write        # required to set the commit status
     outputs:
       pr-sha: ${{ steps.validate-sha.outputs.sha }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - This fix addresses a bug where spark.sql('use ...') would fail with a None database error when the database field wasn't set in profiles.yml, by falling back to the schema value.
 - Fixed incorrect error response assumption in Glue statement output. The `Status` field from `Statement.Output` should only return lowercase `ok` or `error`. The previous check `output.get('Status') == 'ERROR'` would miss non-uppercase, causing errors to silently pass as successful executions.
 - Fixed incremental append and partition_by support for Iceberg Python
+- Secured fork-PR integration test workflows against pwn requests (TOCTOU) by replacing the `pull_request_target` label gate with a `/test glue <sha>` maintainer command that pins the reviewed commit
 
 ## 1.10.19
 

--- a/tests/unit/test_ci_config.py
+++ b/tests/unit/test_ci_config.py
@@ -104,14 +104,20 @@ class TestTriggerPolicy:
         assert "/test glue " in cond, f"{GATE_JOB} must guard on the command prefix"
         assert "pull_request" in cond, f"{GATE_JOB} must run only on PR comments"
 
-        # The gate writes a commit status, so it needs statuses: write.
-        assert gate.get("permissions", {}).get("statuses") == "write", (
+        # The gate needs exactly two write scopes and no more (least privilege):
+        #   - statuses: write     -> set the pending commit status
+        #   - pull-requests: write -> comment on the PR (issues.createComment on a PR
+        #     requires the pull-requests scope; issues: write is not sufficient)
+        perms = gate.get("permissions", {})
+        assert perms.get("statuses") == "write", (
             f"{GATE_JOB} must have statuses: write permission"
         )
-        # Least privilege: the gate handles untrusted comment input and must not
-        # carry write scopes it does not use (e.g. pull-requests: write).
-        assert gate.get("permissions", {}).get("pull-requests") is None, (
-            f"{GATE_JOB} must not request unused pull-requests permission"
+        assert perms.get("pull-requests") == "write", (
+            f"{GATE_JOB} must have pull-requests: write to comment on the PR"
+        )
+        # contents stays read-only: the gate must never get write access to code.
+        assert perms.get("contents") in (None, "read"), (
+            f"{GATE_JOB} must not request contents: write"
         )
 
         # The gate logic lives in the shared composite action; the job must use

--- a/tests/unit/test_ci_config.py
+++ b/tests/unit/test_ci_config.py
@@ -19,9 +19,15 @@ import os
 import pytest
 import yaml
 
-WORKFLOWS_DIR = os.path.join(
-    os.path.dirname(__file__), os.pardir, os.pardir, ".github", "workflows"
+GITHUB_DIR = os.path.join(
+    os.path.dirname(__file__), os.pardir, os.pardir, ".github"
 )
+WORKFLOWS_DIR = os.path.join(GITHUB_DIR, "workflows")
+
+# The gate logic lives in a single composite action shared by all workflows,
+# so the security checks are asserted against it once (not per workflow file).
+GATE_ACTION = os.path.join(GITHUB_DIR, "actions", "check-trigger", "action.yml")
+GATE_ACTION_USES = "./.github/actions/check-trigger"
 
 # (workflow file, secret-bearing PR job, gate job, validated-SHA expression)
 PR_JOBS = [
@@ -46,6 +52,11 @@ FORK_HEAD_REF = "${{ github.event.pull_request.head.sha }}"
 def _load_workflow(filename):
     path = os.path.join(WORKFLOWS_DIR, filename)
     with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _load_gate_action():
+    with open(GATE_ACTION) as f:
         return yaml.safe_load(f)
 
 
@@ -97,14 +108,36 @@ class TestTriggerPolicy:
         assert gate.get("permissions", {}).get("statuses") == "write", (
             f"{GATE_JOB} must have statuses: write permission"
         )
-
-        script = yaml.dump(gate)
-        assert "getCollaboratorPermissionLevel" in script, (
-            f"{GATE_JOB} must check commenter permission"
+        # Least privilege: the gate handles untrusted comment input and must not
+        # carry write scopes it does not use (e.g. pull-requests: write).
+        assert gate.get("permissions", {}).get("pull-requests") is None, (
+            f"{GATE_JOB} must not request unused pull-requests permission"
         )
-        # The SHA-match check is what binds approval to the reviewed commit.
-        assert "head.sha" in script and "SHA mismatch" in script, (
-            f"{GATE_JOB} must reject when the pinned SHA != PR head (TOCTOU guard)"
+
+        # The gate logic lives in the shared composite action; the job must use
+        # it (rather than inlining a copy that could drift).
+        assert _find_step_index(gate, GATE_ACTION_USES) != -1, (
+            f"{GATE_JOB} must run the shared {GATE_ACTION_USES} action"
+        )
+
+    @pytest.mark.parametrize("workflow_file,job_name", PR_JOBS)
+    def test_gate_checks_out_trusted_action_before_use(self, workflow_file, job_name):
+        """The local action must be fetched from the default branch (trusted),
+        and that checkout must not persist credentials."""
+        gate = _load_workflow(workflow_file)["jobs"][GATE_JOB]
+        checkout_idx = _find_step_index(gate, "actions/checkout")
+        action_idx = _find_step_index(gate, GATE_ACTION_USES)
+        assert checkout_idx != -1, f"{GATE_JOB} must check out the repo for the action"
+        assert checkout_idx < action_idx, (
+            f"{GATE_JOB} must check out before using the local action"
+        )
+        # No explicit ref => default branch (trusted gate code), never PR head.
+        checkout = gate["steps"][checkout_idx]
+        assert checkout.get("with", {}).get("ref") is None, (
+            f"{GATE_JOB} checkout must use the default branch, not a PR ref"
+        )
+        assert checkout.get("with", {}).get("persist-credentials") is False, (
+            f"{GATE_JOB} checkout must set persist-credentials: false"
         )
 
 
@@ -223,13 +256,17 @@ class TestCommitStatusReporting:
     """Test results must be reported back to the validated commit as a check."""
 
     @pytest.mark.parametrize("workflow_file,test_job,status_context", STATUS_CONTEXTS)
-    def test_gate_marks_pending(self, workflow_file, test_job, status_context):
-        gate = yaml.dump(_load_workflow(workflow_file)["jobs"][GATE_JOB])
-        assert "createCommitStatus" in gate, (
-            f"{workflow_file} {GATE_JOB} must set a pending commit status"
-        )
-        assert status_context in gate, (
-            f"{workflow_file} {GATE_JOB} must use context '{status_context}'"
+    def test_gate_passes_status_context_to_action(
+        self, workflow_file, test_job, status_context
+    ):
+        """The workflow must pass its status context to the shared gate action,
+        which is what sets the pending commit status."""
+        gate = _load_workflow(workflow_file)["jobs"][GATE_JOB]
+        idx = _find_step_index(gate, GATE_ACTION_USES)
+        assert idx != -1, f"{workflow_file} {GATE_JOB} must use the gate action"
+        with_ = gate["steps"][idx].get("with", {})
+        assert with_.get("status-context") == status_context, (
+            f"{workflow_file} {GATE_JOB} must pass status-context '{status_context}'"
         )
 
     @pytest.mark.parametrize("workflow_file,test_job,status_context", STATUS_CONTEXTS)
@@ -257,4 +294,45 @@ class TestCommitStatusReporting:
         )
         assert "needs.check-trigger.outputs.pr-sha" in body, (
             "report-status must report against the validated SHA"
+        )
+
+
+# ── Shared gate action ─────────────────────────────────────────────────
+
+
+class TestGateAction:
+    """The security logic shared by all workflows lives in one composite action.
+
+    These are the core pwn-request defenses; assert them on the action itself so
+    they cannot silently weaken (the workflow files no longer inline this code).
+    """
+
+    def test_is_composite_action_with_sha_output(self):
+        action = _load_gate_action()
+        assert action.get("runs", {}).get("using") == "composite", (
+            "check-trigger must be a composite action"
+        )
+        assert "sha" in action.get("outputs", {}), (
+            "gate action must expose the validated 'sha' output"
+        )
+        assert {"status-context", "test-name"} <= set(action.get("inputs", {})), (
+            "gate action must accept status-context and test-name inputs"
+        )
+
+    def test_enforces_permission_sha_and_toctou(self):
+        script = yaml.dump(_load_gate_action())
+        assert "getCollaboratorPermissionLevel" in script, (
+            "gate must check commenter permission"
+        )
+        assert "['admin', 'write']" in script, (
+            "gate must require admin/write permission"
+        )
+        # Full 40-char SHA must be pinned in the comment.
+        assert "[a-f0-9]{40}" in script, "gate must require a full 40-char SHA"
+        # The SHA-match check is what binds approval to the reviewed commit.
+        assert "head.sha" in script and "SHA mismatch" in script, (
+            "gate must reject when the pinned SHA != PR head (TOCTOU guard)"
+        )
+        assert "createCommitStatus" in script, (
+            "gate must set a pending commit status on the validated SHA"
         )

--- a/tests/unit/test_ci_config.py
+++ b/tests/unit/test_ci_config.py
@@ -93,6 +93,11 @@ class TestTriggerPolicy:
         assert "/test glue " in cond, f"{GATE_JOB} must guard on the command prefix"
         assert "pull_request" in cond, f"{GATE_JOB} must run only on PR comments"
 
+        # The gate writes a commit status, so it needs statuses: write.
+        assert gate.get("permissions", {}).get("statuses") == "write", (
+            f"{GATE_JOB} must have statuses: write permission"
+        )
+
         script = yaml.dump(gate)
         assert "getCollaboratorPermissionLevel" in script, (
             f"{GATE_JOB} must check commenter permission"
@@ -191,8 +196,65 @@ class TestWorkflowConfig:
 
 
 class TestPythonModelsJobList:
-    """python-models.yml is PR-only: gate + test job, no push-to-main job."""
+    """python-models.yml is PR-only: gate + test + report job, no push-to-main."""
 
     def test_expected_jobs_only(self):
         wf = _load_workflow("python-models.yml")
-        assert set(wf["jobs"].keys()) == {GATE_JOB, "python-model-tests-pr"}
+        assert set(wf["jobs"].keys()) == {
+            GATE_JOB,
+            "python-model-tests-pr",
+            "report-status",
+        }
+
+
+# ── Commit-status reporting ────────────────────────────────────────────
+
+# Each workflow reports its outcome as a commit status so the result becomes a
+# PR check (and can be made a required check via branch protection). Without
+# this, comment-triggered tests never gate merges -- the regression #678 left.
+STATUS_CONTEXTS = [
+    ("integration.yml", "functional-tests-pr", "integration-tests"),
+    ("python-models.yml", "python-model-tests-pr", "python-model-tests"),
+    ("s3-tables.yml", "test-s3-tables", "s3-tables-tests"),
+]
+
+
+class TestCommitStatusReporting:
+    """Test results must be reported back to the validated commit as a check."""
+
+    @pytest.mark.parametrize("workflow_file,test_job,status_context", STATUS_CONTEXTS)
+    def test_gate_marks_pending(self, workflow_file, test_job, status_context):
+        gate = yaml.dump(_load_workflow(workflow_file)["jobs"][GATE_JOB])
+        assert "createCommitStatus" in gate, (
+            f"{workflow_file} {GATE_JOB} must set a pending commit status"
+        )
+        assert status_context in gate, (
+            f"{workflow_file} {GATE_JOB} must use context '{status_context}'"
+        )
+
+    @pytest.mark.parametrize("workflow_file,test_job,status_context", STATUS_CONTEXTS)
+    def test_report_job_reports_outcome(self, workflow_file, test_job, status_context):
+        wf = _load_workflow(workflow_file)
+        assert "report-status" in wf["jobs"], f"{workflow_file} missing report-status"
+        report = wf["jobs"]["report-status"]
+
+        # Must run even when the test job failed, but only if the gate passed,
+        # so a real failure is surfaced as a failing check (not a skipped one).
+        cond = report.get("if", "")
+        assert "always()" in cond, "report-status must use always()"
+        assert "check-trigger" in cond, "report-status must require gate success"
+
+        needs = report.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        assert GATE_JOB in needs and test_job in needs, (
+            f"report-status must depend on {GATE_JOB} and {test_job}"
+        )
+
+        body = yaml.dump(report)
+        assert "createCommitStatus" in body, "report-status must set a commit status"
+        assert status_context in body, (
+            f"report-status must report context '{status_context}'"
+        )
+        assert "needs.check-trigger.outputs.pr-sha" in body, (
+            "report-status must report against the validated SHA"
+        )

--- a/tests/unit/test_ci_config.py
+++ b/tests/unit/test_ci_config.py
@@ -221,7 +221,7 @@ class TestMainJobs:
 
 
 class TestWorkflowConfig:
-    """id-token must not be writable in the comment-triggered workflows."""
+    """Workflow-level config: permissions and concurrency must be declared."""
 
     @pytest.mark.parametrize("workflow_file", ALL_WORKFLOW_FILES)
     def test_permissions_present(self, workflow_file):

--- a/tests/unit/test_ci_config.py
+++ b/tests/unit/test_ci_config.py
@@ -1,13 +1,19 @@
 """CI workflow configuration policy tests.
 
-Validates that GitHub Actions workflow files follow project conventions:
-- Checkout steps use default refs in pull_request_target workflows
-- AWS credentials are configured in the expected order
-- Push-to-main jobs and workflow-level config remain stable
-- Triggers, concurrency, and permissions blocks are consistent
+Fork PRs run untrusted code against real AWS Glue, which requires secrets.
+The secret-bearing PR jobs are therefore gated so that they cannot run
+untrusted code without an explicit, commit-pinned maintainer approval
+(see the ``check-trigger`` job in each workflow). These tests assert the
+security-relevant properties of that design so it cannot silently regress:
+
+- PR jobs are triggered by ``issue_comment`` (a maintainer command), not by
+  the ``pull_request_target: labeled`` pattern that is prone to TOCTOU.
+- A ``check-trigger`` gate job validates the commenter and the pinned SHA.
+- PR jobs depend on that gate and check out *only* the validated SHA, never
+  the live PR head (``github.event.pull_request.head.sha``).
+- Push-to-main jobs keep running tox/pytest with AWS credentials.
 """
 
-import copy
 import os
 
 import pytest
@@ -17,16 +23,21 @@ WORKFLOWS_DIR = os.path.join(
     os.path.dirname(__file__), os.pardir, os.pardir, ".github", "workflows"
 )
 
-ALL_WORKFLOW_FILES = ["integration.yml", "python-models.yml", "s3-tables.yml"]
-
-# PR-triggered jobs that should use default checkout ref
+# (workflow file, secret-bearing PR job, gate job, validated-SHA expression)
 PR_JOBS = [
     ("integration.yml", "functional-tests-pr"),
     ("python-models.yml", "python-model-tests-pr"),
     ("s3-tables.yml", "test-s3-tables"),
 ]
 
-FORK_REF = "${{ github.event.pull_request.head.sha }}"
+ALL_WORKFLOW_FILES = [wf for wf, _ in PR_JOBS]
+
+GATE_JOB = "check-trigger"
+VALIDATED_REF = "${{ needs.check-trigger.outputs.pr-sha }}"
+
+# The live fork HEAD must never be checked out in a secret-bearing job: that is
+# the pwn-request sink this design exists to remove.
+FORK_HEAD_REF = "${{ github.event.pull_request.head.sha }}"
 
 
 # ── Helpers ────────────────────────────────────────────────────────────
@@ -47,185 +58,141 @@ def _find_step_index(job, action_fragment):
 
 
 def _triggers(wf):
-    """Extract the 'on:' block (PyYAML parses bare 'on' as boolean True)."""
+    """Extract the 'on:' block (PyYAML parses the bare key 'on' as boolean True)."""
     return wf.get(True) or wf.get("on")
 
 
-def _dict_diff_keys(expected, actual):
-    """Return a summary of top-level keys that differ between two dicts."""
-    diffs = []
-    for k in sorted(set(list(expected.keys()) + list(actual.keys()))):
-        if k not in expected:
-            diffs.append(f"+{k} (added)")
-        elif k not in actual:
-            diffs.append(f"-{k} (removed)")
-        elif expected[k] != actual[k]:
-            diffs.append(f"~{k} (changed)")
-    return diffs
+# ── Trigger policy ─────────────────────────────────────────────────────
 
 
-# ── Baselines (captured once at import time) ───────────────────────────
+class TestTriggerPolicy:
+    """Secret-bearing PR tests must be gated by a maintainer comment command."""
 
-def _snapshot_baselines():
-    """Capture current workflow structure as the baseline for drift detection."""
-    integration = _load_workflow("integration.yml")
-    python_models = _load_workflow("python-models.yml")
-    s3_tables = _load_workflow("s3-tables.yml")
+    @pytest.mark.parametrize("workflow_file,job_name", PR_JOBS)
+    def test_triggered_by_issue_comment(self, workflow_file, job_name):
+        """The workflow must run on issue_comment, not pull_request_target."""
+        triggers = _triggers(_load_workflow(workflow_file))
+        assert "issue_comment" in triggers, (
+            f"{workflow_file} must be triggered by issue_comment"
+        )
+        # pull_request_target + checkout of fork code is the pwn-request pattern
+        # this design removes; it must not come back.
+        assert "pull_request_target" not in triggers, (
+            f"{workflow_file} must not use pull_request_target"
+        )
 
-    return {
-        "integration_main_job": copy.deepcopy(
-            integration["jobs"]["functional-tests-main"]
-        ),
-        "s3_tables_main_job": copy.deepcopy(
-            s3_tables["jobs"]["s3-tables-tests-main"]
-        ),
-        "triggers": {
-            "integration.yml": copy.deepcopy(_triggers(integration)),
-            "python-models.yml": copy.deepcopy(_triggers(python_models)),
-            "s3-tables.yml": copy.deepcopy(_triggers(s3_tables)),
-        },
-        "concurrency": {
-            "integration.yml": copy.deepcopy(integration["concurrency"]),
-            "python-models.yml": copy.deepcopy(python_models["concurrency"]),
-            "s3-tables.yml": copy.deepcopy(s3_tables["concurrency"]),
-        },
-        "permissions": {
-            "integration.yml": copy.deepcopy(integration["permissions"]),
-            "python-models.yml": copy.deepcopy(python_models["permissions"]),
-            "s3-tables.yml": copy.deepcopy(s3_tables["permissions"]),
-        },
-        "python_models_jobs": list(python_models["jobs"].keys()),
-    }
+    @pytest.mark.parametrize("workflow_file,job_name", PR_JOBS)
+    def test_has_gate_job(self, workflow_file, job_name):
+        """A check-trigger gate job must exist and validate the comment."""
+        wf = _load_workflow(workflow_file)
+        assert GATE_JOB in wf["jobs"], f"{workflow_file} missing {GATE_JOB} job"
+
+        gate = wf["jobs"][GATE_JOB]
+        cond = gate.get("if", "")
+        assert "issue_comment" in cond, f"{GATE_JOB} must guard on issue_comment"
+        assert "/test glue " in cond, f"{GATE_JOB} must guard on the command prefix"
+        assert "pull_request" in cond, f"{GATE_JOB} must run only on PR comments"
+
+        script = yaml.dump(gate)
+        assert "getCollaboratorPermissionLevel" in script, (
+            f"{GATE_JOB} must check commenter permission"
+        )
+        # The SHA-match check is what binds approval to the reviewed commit.
+        assert "head.sha" in script and "SHA mismatch" in script, (
+            f"{GATE_JOB} must reject when the pinned SHA != PR head (TOCTOU guard)"
+        )
 
 
-_BASELINES = _snapshot_baselines()
-
-
-# ── Checkout ref policy ────────────────────────────────────────────────
+# ── Checkout policy ────────────────────────────────────────────────────
 
 
 class TestCheckoutPolicy:
-    """PR jobs using pull_request_target must use the default checkout ref."""
+    """PR jobs must check out only the gate-validated SHA, never the live head."""
 
     @pytest.mark.parametrize("workflow_file,job_name", PR_JOBS)
-    def test_pr_job_uses_default_ref(self, workflow_file, job_name):
-        """Checkout step should not override ref to fork HEAD."""
+    def test_pr_job_needs_gate(self, workflow_file, job_name):
+        wf = _load_workflow(workflow_file)
+        job = wf["jobs"][job_name]
+        needs = job.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        assert GATE_JOB in needs, (
+            f"{workflow_file} → {job_name} must depend on {GATE_JOB}"
+        )
+
+    @pytest.mark.parametrize("workflow_file,job_name", PR_JOBS)
+    def test_pr_job_checks_out_validated_sha(self, workflow_file, job_name):
         wf = _load_workflow(workflow_file)
         job = wf["jobs"][job_name]
         idx = _find_step_index(job, "actions/checkout")
         assert idx != -1, f"No checkout step in {job_name}"
 
         ref = job["steps"][idx].get("with", {}).get("ref")
-        assert ref != FORK_REF, (
-            f"{workflow_file} → {job_name} should use default checkout ref"
+        assert ref == VALIDATED_REF, (
+            f"{workflow_file} → {job_name} must check out the validated SHA "
+            f"({VALIDATED_REF}), got {ref!r}"
+        )
+        assert ref != FORK_HEAD_REF, (
+            f"{workflow_file} → {job_name} must never check out the live fork HEAD"
         )
 
     @pytest.mark.parametrize("workflow_file,job_name", PR_JOBS)
-    def test_credentials_before_fork_checkout(self, workflow_file, job_name):
-        """AWS credentials must not follow a fork-code checkout."""
+    def test_pr_job_does_not_persist_credentials(self, workflow_file, job_name):
         wf = _load_workflow(workflow_file)
         job = wf["jobs"][job_name]
-
-        checkout_idx = _find_step_index(job, "actions/checkout")
-        creds_idx = _find_step_index(job, "configure-aws-credentials")
-        assert checkout_idx != -1, f"No checkout step in {job_name}"
-        assert creds_idx != -1, f"No credentials step in {job_name}"
-
-        ref = job["steps"][checkout_idx].get("with", {}).get("ref")
-        if ref == FORK_REF:
-            assert creds_idx < checkout_idx, (
-                f"{workflow_file} → {job_name}: credentials step should "
-                f"precede fork-code checkout"
-            )
-
-
-# ── Workflow structure stability ───────────────────────────────────────
-
-
-class TestMainJobStability:
-    """Push-to-main jobs must not drift from their expected structure."""
-
-    def test_functional_tests_main(self):
-        wf = _load_workflow("integration.yml")
-        actual = wf["jobs"]["functional-tests-main"]
-        baseline = _BASELINES["integration_main_job"]
-        assert actual == baseline, (
-            "functional-tests-main structure drifted.\n"
-            f"Diff: {_dict_diff_keys(baseline, actual)}"
+        idx = _find_step_index(job, "actions/checkout")
+        assert idx != -1, f"No checkout step in {job_name}"
+        assert job["steps"][idx].get("with", {}).get("persist-credentials") is False, (
+            f"{workflow_file} → {job_name} checkout must set persist-credentials: false"
         )
 
-    def test_s3_tables_tests_main(self):
-        wf = _load_workflow("s3-tables.yml")
-        actual = wf["jobs"]["s3-tables-tests-main"]
-        baseline = _BASELINES["s3_tables_main_job"]
-        assert actual == baseline, (
-            "s3-tables-tests-main structure drifted.\n"
-            f"Diff: {_dict_diff_keys(baseline, actual)}"
+
+# ── Push-to-main jobs ──────────────────────────────────────────────────
+
+MAIN_JOBS = [
+    ("integration.yml", "functional-tests-main", "tox"),
+    ("s3-tables.yml", "s3-tables-tests-main", "pytest"),
+]
+
+
+class TestMainJobs:
+    """Push-to-main jobs run trusted code and must keep credentials + runner."""
+
+    @pytest.mark.parametrize("workflow_file,job_name,runner", MAIN_JOBS)
+    def test_main_job_present_and_push_gated(self, workflow_file, job_name, runner):
+        wf = _load_workflow(workflow_file)
+        assert job_name in wf["jobs"], f"{workflow_file} missing {job_name}"
+        job = wf["jobs"][job_name]
+        assert "push" in str(job.get("if", "")), (
+            f"{job_name} must be gated on push to main"
+        )
+        assert _find_step_index(job, "configure-aws-credentials") != -1, (
+            f"{job_name} must configure AWS credentials"
+        )
+        assert any(runner in s.get("run", "") for s in job["steps"]), (
+            f"{job_name} must run {runner}"
         )
 
-    def test_functional_tests_main_step_count(self):
-        wf = _load_workflow("integration.yml")
-        steps = wf["jobs"]["functional-tests-main"]["steps"]
-        assert len(steps) == 8, f"Expected 8 steps, got {len(steps)}"
 
-    def test_s3_tables_tests_main_step_count(self):
-        wf = _load_workflow("s3-tables.yml")
-        steps = wf["jobs"]["s3-tables-tests-main"]["steps"]
-        assert len(steps) == 7, f"Expected 7 steps, got {len(steps)}"
-
-    def test_functional_tests_main_has_credentials(self):
-        wf = _load_workflow("integration.yml")
-        job = wf["jobs"]["functional-tests-main"]
-        assert _find_step_index(job, "configure-aws-credentials") != -1
-
-    def test_s3_tables_tests_main_has_credentials(self):
-        wf = _load_workflow("s3-tables.yml")
-        job = wf["jobs"]["s3-tables-tests-main"]
-        assert _find_step_index(job, "configure-aws-credentials") != -1
-
-    def test_functional_tests_main_has_tox(self):
-        wf = _load_workflow("integration.yml")
-        job = wf["jobs"]["functional-tests-main"]
-        assert any("tox" in s.get("run", "") for s in job["steps"])
-
-    def test_s3_tables_tests_main_has_pytest(self):
-        wf = _load_workflow("s3-tables.yml")
-        job = wf["jobs"]["s3-tables-tests-main"]
-        assert any("pytest" in s.get("run", "") for s in job["steps"])
-
-
-# ── Workflow-level config stability ────────────────────────────────────
+# ── Workflow-level config ──────────────────────────────────────────────
 
 
 class TestWorkflowConfig:
-    """Triggers, concurrency, and permissions must stay consistent."""
+    """id-token must not be writable in the comment-triggered workflows."""
 
     @pytest.mark.parametrize("workflow_file", ALL_WORKFLOW_FILES)
-    def test_triggers(self, workflow_file):
+    def test_permissions_present(self, workflow_file):
         wf = _load_workflow(workflow_file)
-        assert _triggers(wf) == _BASELINES["triggers"][workflow_file]
+        assert "permissions" in wf, f"{workflow_file} must declare permissions"
 
     @pytest.mark.parametrize("workflow_file", ALL_WORKFLOW_FILES)
-    def test_concurrency(self, workflow_file):
+    def test_concurrency_present(self, workflow_file):
         wf = _load_workflow(workflow_file)
-        assert wf["concurrency"] == _BASELINES["concurrency"][workflow_file]
-
-    @pytest.mark.parametrize("workflow_file", ALL_WORKFLOW_FILES)
-    def test_permissions(self, workflow_file):
-        wf = _load_workflow(workflow_file)
-        assert wf["permissions"] == _BASELINES["permissions"][workflow_file]
+        assert "concurrency" in wf, f"{workflow_file} must declare concurrency"
 
 
 class TestPythonModelsJobList:
-    """python-models.yml should only contain the expected jobs."""
-
-    def test_no_push_job(self):
-        wf = _load_workflow("python-models.yml")
-        for name, job in wf["jobs"].items():
-            assert "push" not in str(job.get("if", "")), (
-                f"Unexpected push job: {name}"
-            )
+    """python-models.yml is PR-only: gate + test job, no push-to-main job."""
 
     def test_expected_jobs_only(self):
         wf = _load_workflow("python-models.yml")
-        assert list(wf["jobs"].keys()) == _BASELINES["python_models_jobs"]
+        assert set(wf["jobs"].keys()) == {GATE_JOB, "python-model-tests-pr"}


### PR DESCRIPTION
### Description

Fork PRs run untrusted code against CI AWS environment, which requires repository secrets (`DBT_GLUE_ROLE_ARN`, etc.). This may result in a [pwn request](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) where the workflow checks out untrusted fork code in a context that has access to secrets and a write-scoped token.

This PR reworks how the secret-bearing PR test workflows (`integration.yml`, `python-models.yml`, `s3-tables.yml`) are triggered so that:

1. **Only a maintainer can start them**: via a `/test glue <40-char-sha>` comment, gated on the commenter's `write`/`admin` permission.
2. **The approval is bound to the exact reviewed commit**: the workflow verifies the SHA in the comment still equals the PR head, so a commit pushed after review cannot be substituted (TOCTOU).
3. **The result is reported back as a PR commit status**: so comment-triggered runs actually gate merges, instead of passing/failing invisibly.

#### Background: why the previous approach was unsafe

The workflows used `pull_request_target: [labeled]` + a label gate (`enable-functional-tests`) + `ref: ${{ github.event.pull_request.head.sha }}`.

That pattern has a TOCTOU window:

```
T1: attacker pushes commit A
T2: maintainer reviews A (looks safe)
T3: attacker pushes malicious commit B (swap)
T4: maintainer adds label -> labeled event pins head.sha = B
T5: checkout ref=B -> B runs with secrets (maintainer approved A, B executes = pwn)
```

The commit is pinned at **label time (T4)**, not **review time (T2)**, and a label is not bound to the reviewed commit.

#### Relationship to #678

[#678](https://github.com/aws-samples/dbt-glue/pull/678) correctly recognized that checking out the fork HEAD under `pull_request_target` is dangerous, and removed the explicit `ref:`. But the default ref under `pull_request_target` is the **base branch (`main`)**, so afterwards the PR's own code was no longer tested: the jobs ran against `main` regardless of PR contents. This PR restores testing of the PR code **and** closes the pwn-request hole that simply restoring `ref: head.sha` would reopen.

#### How it works

Each PR workflow now:

- Triggers on `issue_comment: [created]` instead of `pull_request_target: [labeled]`.
- Runs a `check-trigger` gate job that:
  1. Verifies the commenter has `write`/`admin` permission (`getCollaboratorPermissionLevel`).
  2. Parses a full 40-char SHA from `/test glue <sha>`.
  3. Rejects with `SHA mismatch - possible TOCTOU` if the pinned SHA does not equal the current PR head.
  4. Sets a `pending` commit status on the validated SHA.
- Runs the test job with `ref: ${{ needs.check-trigger.outputs.pr-sha }}` (the validated SHA only, never the live head) and `persist-credentials: false`.
- Runs a `report-status` job (`if: always()` once the gate passed) that writes the final `success`/`failure` commit status.

Status contexts: `integration-tests`, `python-model-tests`, `s3-tables-tests`. The gate logic (permission check, SHA validation, TOCTOU guard, commit-status creation) lives in a shared composite action (`.github/actions/check-trigger/action.yml`) so it is maintained in one place. Each workflow checks out the action from the default branch and calls it with its own `status-context` and `test-name` inputs.

#### Usage for maintainers

Review the PR, then comment:

```
/test glue <full-40-char-sha-of-the-reviewed-commit>
```

If the SHA still matches the PR head, the tests run against that commit and report back as PR checks. If the PR is updated after review, the command is rejected and you re-review and re-issue it with the new SHA.

#### The `enable-functional-tests` label is no longer used

The label gate is fully replaced by the `/test glue` command. No workflow references `enable-functional-tests` anymore, and it is not mentioned in README/CONTRIBUTING, so no docs change is required. Maintainers can delete the label from the repo at their convenience.

####  Reference implementation

This implementation follows the pattern in [`aws/aws-network-policy-agent`](https://github.com/aws/aws-network-policy-agent), see [PR #560 "Fix TOCTOU and permission vulnerabilities"](https://github.com/aws/aws-network-policy-agent/pull/560), which gates fork-PR integration tests against real AWS the same way (`/test cyclonus <sha>` + SHA-match check). Related: `huggingface/transformers` (`self-comment-ci.yml`), `external-secrets/external-secrets` (`/ok-to-test-managed`).

#### Testing

Verified the behavior on a fork (https://github.com/yotahk/dbt-glue/pull/4 ):

- Valid SHA from a maintainer: gate passes, validated SHA is checked out, `pending` then final status posted.
- Mismatched SHA: `SHA mismatch - possible TOCTOU`, no status created, no test run.
- Non-maintainer / malformed command: rejected.
- **After CI passes, pushing a new commit moves the PR head to an unverified SHA that has no status, so the required checks become unsatisfied and the PR is blocked from merging** until the maintainer re-reviews and re-runs `/test glue <new-sha>`. (Confirmed `mergeStateStatus: BLOCKED` with required checks configured.)

`tests/unit/test_ci_config.py` was rewritten to assert the security properties of this design (trigger type, gate checks, validated-SHA checkout, `persist-credentials: false`, commit-status reporting) instead of the previous self-referential drift baselines.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.