### PR TITLE
fix: stop calling GetSession per query inside the Glue session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## dbt-glue next
+
+- Fixed `ThrottlingException` on the Glue `GetSession` API when `use_arrow` is enabled. The session's `SecurityConfiguration` is now resolved once per session instead of on every query, the boto3 clients created inside the session are reused, and they honour the profile's `boto_retry_mode` and `boto_retry_max_attempts` instead of botocore's legacy retry policy.
+
 ## v1.12.3
 
 - Fixed `ref()` and `source()` in Python models to use dbt-core's resolved functions

--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ The table below describes all the options.
 | datalake_formats	                       | The ACID datalake format that you want to use if you are doing merge, can be `hudi`, `iceberg` or `delta`                                                                                                                                                                                         |no|
 | use_arrow	                           | (experimental) use an arrow file instead of stdout to have better scalability.                                                                                                                                                                                                                    |no|
 | enable_spark_seed_casting	              | Allows spark to cast the columns depending on the specified model column types. Default `False`.        |no|
+| statement_poll_interval	              | Interval in seconds between polls for statement completion. Must be >= 1. Default `1.0`.        |no|
+| boto_retry_mode	                      | The botocore retry mode used by the adapter's AWS clients and by the boto3 clients created inside the Glue session. One of `legacy`, `standard` or `adaptive`. Default `adaptive`, which adds client-side throttling and is the most resilient to `ThrottlingException`. |no|
+| boto_retry_max_attempts	              | The maximum number of attempts botocore makes per AWS API call. Must be greater than 0. Default `10`. Increase this if you still see `ThrottlingException` / `Rate exceeded` errors on Glue APIs. |no|
 
 ## Configs
 

--- a/dbt/adapters/glue/gluedbapi/connection.py
+++ b/dbt/adapters/glue/gluedbapi/connection.py
@@ -216,12 +216,30 @@ class GlueConnection:
 
         return
 
+    def _boto_retry_options(self) -> dict:
+        retry_options = {
+            "max_attempts": self.credentials.boto_retry_max_attempts,
+        }
+        if self.credentials.boto_retry_mode:
+            retry_options["mode"] = self.credentials.boto_retry_mode
+        return retry_options
+
+    def _render_boto_preamble(self) -> str:
+        """Renders the preamble. `repr` keeps profile values from injecting code."""
+        return SQLPROXY_BOTO_PREAMBLE_TEMPLATE.replace(
+            "${BOTO_RETRIES}", repr(self._boto_retry_options())
+        )
+
+    def _render_sqlproxy(self) -> str:
+        """Renders the SQLPROXY_TEMPLATE code that runs inside the Glue session."""
+        return SQLPROXY_TEMPLATE.replace("${BOTO_PREAMBLE}", self._render_boto_preamble())
+
     def _init_session(self):
         logger.debug("GlueConnection _init_session called for session_id : " + self.session_id)
         statement = GlueStatement(
             client=self.client,
             session_id=self.session_id,
-            code=SQLPROXY,
+            code=self._render_sqlproxy(),
             poll_interval=self.credentials.statement_poll_interval,
         )
         try:
@@ -265,13 +283,7 @@ class GlueConnection:
 
     @property
     def client(self):
-        retry_options = {
-            "max_attempts": self.credentials.boto_retry_max_attempts,
-        }
-        if self.credentials.boto_retry_mode:
-            retry_options["mode"] = self.credentials.boto_retry_mode
-
-        config = Config(retries=retry_options)
+        config = Config(retries=self._boto_retry_options())
         if not self._client:
             # reference on why lock is required - https://stackoverflow.com/a/61943955/6034432
             with self._boto3_client_lock:
@@ -393,7 +405,57 @@ class GlueConnection:
         return value_in_dictionary
 
 
-SQLPROXY = """
+# Injected into SQLPROXY_TEMPLATE. Separate so it can be rendered and tested on its own.
+SQLPROXY_BOTO_PREAMBLE_TEMPLATE = """
+# Retry configuration for the in-session boto3 clients, injected from the
+# `boto_retry_mode` / `boto_retry_max_attempts` profile options. Without it these
+# clients use the legacy botocore policy (4 attempts, no backoff) and surface
+# throttling as ThrottlingException.
+BOTO_CONFIG = Config(retries=${BOTO_RETRIES})
+
+try:
+    _UPLOAD_EXTRA_ARGS
+except NameError:
+    _S3_CLIENT = None
+    _GLUE_CLIENT = None
+    _UPLOAD_EXTRA_ARGS = None
+
+def _get_s3_client():
+    global _S3_CLIENT
+    if _S3_CLIENT is None:
+        _S3_CLIENT = boto3.client('s3', config=BOTO_CONFIG)
+    return _S3_CLIENT
+
+def _get_glue_client():
+    global _GLUE_CLIENT
+    if _GLUE_CLIENT is None:
+        _GLUE_CLIENT = boto3.client('glue', config=BOTO_CONFIG)
+    return _GLUE_CLIENT
+
+def _get_upload_extra_args():
+    # SecurityConfiguration is fixed for the session's lifetime, so it is resolved once instead of per query
+    global _UPLOAD_EXTRA_ARGS
+    if _UPLOAD_EXTRA_ARGS is None:
+        glue_client = _get_glue_client()
+        extra_args = {}
+        security_config_name = glue_client.get_session(Id=session_id)["Session"].get("SecurityConfiguration", None)
+        if security_config_name:
+            security_config = glue_client.get_security_configuration(Name=security_config_name)
+            s3_encryption = security_config["SecurityConfiguration"]["EncryptionConfiguration"].get("S3Encryption", None)
+            if s3_encryption and len(s3_encryption) > 0:
+                s3_encryption_mode = s3_encryption[0]["S3EncryptionMode"]
+                kms_key_arn = s3_encryption[0].get("KmsKeyArn", None)
+                if s3_encryption_mode == "SSE-S3":
+                    extra_args["ServerSideEncryption"] = "AES256"
+                elif s3_encryption_mode == "SSE-KMS":
+                    extra_args["ServerSideEncryption"] = "aws:kms"
+                    extra_args["SSEKMSKeyId"] = kms_key_arn.split("/")[1]
+        _UPLOAD_EXTRA_ARGS = extra_args
+    return dict(_UPLOAD_EXTRA_ARGS)
+"""
+
+
+SQLPROXY_TEMPLATE = """
 import sys
 import json
 import base64
@@ -401,6 +463,7 @@ import urllib
 import pandas as pd
 import pyarrow.feather as feather
 import boto3
+from botocore.config import Config
 import string
 import random
 from awsglue.utils import getResolvedOptions
@@ -409,6 +472,7 @@ if '--SESSION_ID' in sys.argv:
     params.append('SESSION_ID')
 args = getResolvedOptions(sys.argv, params)
 session_id = args.get("SESSION_ID", "unknown-session")
+${BOTO_PREAMBLE}
 
 class SqlWrapper2:
     i = 0
@@ -446,9 +510,7 @@ class SqlWrapper2:
         raw_results = {"type": "results", "rowcount": rowcount, "results": results, "description": description}
 
         if use_arrow:
-            s3_client = boto3.client('s3')
-            glue_client = boto3.client('glue')
-            security_config_name = glue_client.get_session(Id=session_id)["Session"].get("SecurityConfiguration", None)
+            s3_client = _get_s3_client()
             o = urllib.parse.urlparse(location)
             result_bucket = o.netloc
             key = urllib.parse.unquote(o.path)[1:]
@@ -460,18 +522,7 @@ class SqlWrapper2:
             pdf = pd.DataFrame.from_dict(raw_results, orient="index")
             feather.write_feather(pdf.transpose(), filename, "zstd")
 
-            extra_args = {}
-            if security_config_name:
-                security_config = glue_client.get_security_configuration(Name=security_config_name)
-                s3_encryption = security_config["SecurityConfiguration"]["EncryptionConfiguration"].get("S3Encryption", None)
-                if s3_encryption and len(s3_encryption) > 0:
-                    s3_encryption_mode = s3_encryption[0]["S3EncryptionMode"]
-                    kms_key_arn = s3_encryption[0].get("KmsKeyArn", None)
-                    if s3_encryption_mode == "SSE-S3":
-                        extra_args["ServerSideEncryption"] = "AES256"
-                    elif s3_encryption_mode == "SSE-KMS":
-                        extra_args["ServerSideEncryption"] = "aws:kms"
-                        extra_args["SSEKMSKeyId"] = kms_key_arn.split("/")[1]
+            extra_args = _get_upload_extra_args()
             s3_client.upload_file(filename, result_bucket, result_key, ExtraArgs=extra_args)
             # Print and return only metadata instead of actual result data payload. The param use_arrow=True is always
             # used with output=True, and stdout is used to pass those values to Interactive Sessions API.

--- a/tests/unit/gluedbapi/test_connection.py
+++ b/tests/unit/gluedbapi/test_connection.py
@@ -36,3 +36,157 @@ class TestGlueConnection(unittest.TestCase):
         retries = kwargs["config"].retries
         assert retries["max_attempts"] == 4
         assert retries["mode"] == "standard"
+
+    def test_render_sqlproxy_injects_retry_config(self) -> None:
+        credentials = GlueCredentials(
+            boto_retry_mode="standard",
+            boto_retry_max_attempts=7,
+        )
+        connection = GlueConnection(credentials)
+
+        rendered = connection._render_sqlproxy()
+
+        assert "${BOTO_PREAMBLE}" not in rendered
+        assert "${BOTO_RETRIES}" not in rendered
+        assert "Config(retries={'max_attempts': 7, 'mode': 'standard'})" in rendered
+        assert "boto3.client('glue', config=BOTO_CONFIG)" in rendered
+        assert "boto3.client('s3', config=BOTO_CONFIG)" in rendered
+        compile(rendered, "<sqlproxy>", "exec")
+
+    def test_render_sqlproxy_omits_unset_retry_mode(self) -> None:
+        credentials = GlueCredentials(
+            boto_retry_mode=None,
+            boto_retry_max_attempts=10,
+        )
+        connection = GlueConnection(credentials)
+
+        rendered = connection._render_sqlproxy()
+
+        assert "Config(retries={'max_attempts': 10})" in rendered
+        compile(rendered, "<sqlproxy>", "exec")
+
+    def _exec_preamble(self, credentials, glue_client, namespace=None):
+        """Execs the rendered preamble with a stubbed boto3. Pass a `namespace` to
+        re-send it into a session that already ran it, as cursor() does per query."""
+        connection = GlueConnection(credentials)
+        code = connection._render_boto_preamble()
+
+        def fake_client(service, **kwargs):
+            return glue_client if service == "glue" else mock.Mock()
+
+        if namespace is None:
+            namespace = {
+                "boto3": mock.Mock(client=mock.Mock(side_effect=fake_client)),
+                "Config": mock.Mock(),
+                "session_id": "mock-session-id",
+            }
+        exec(compile(code, "<preamble>", "exec"), namespace)
+        return namespace
+
+    def test_retry_mode_cannot_inject_code_into_the_session(self) -> None:
+        """The retry options are interpolated into code executed inside the session."""
+        malicious = "standard'}) ; raise AssertionError('injected')  #"
+        glue_client = mock.Mock()
+        glue_client.get_session.return_value = {"Session": {}}
+
+        namespace = self._exec_preamble(
+            GlueCredentials(boto_retry_mode=malicious), glue_client
+        )
+
+        namespace["Config"].assert_called_once_with(
+            retries={"max_attempts": 10, "mode": malicious}
+        )
+
+    def test_in_session_security_config_lookup_is_cached(self) -> None:
+        """GetSession/GetSecurityConfiguration must not run per query: doing so is
+        what exhausted the rate limit and surfaced as ThrottlingException."""
+        glue_client = mock.Mock()
+        glue_client.get_session.return_value = {
+            "Session": {"SecurityConfiguration": "my-sec-config"}
+        }
+        glue_client.get_security_configuration.return_value = {
+            "SecurityConfiguration": {
+                "EncryptionConfiguration": {
+                    "S3Encryption": [{"S3EncryptionMode": "SSE-S3"}]
+                }
+            }
+        }
+
+        namespace = self._exec_preamble(GlueCredentials(), glue_client)
+
+        results = [namespace["_get_upload_extra_args"]() for _ in range(5)]
+
+        assert glue_client.get_session.call_count == 1
+        assert glue_client.get_security_configuration.call_count == 1
+        assert all(r == {"ServerSideEncryption": "AES256"} for r in results)
+
+    def test_in_session_cache_survives_session_re_init(self) -> None:
+        """cursor() re-sends SQLPROXY before every query into the same interpreter, so
+        resetting the sentinels there would leave GetSession running once per query."""
+        glue_client = mock.Mock()
+        glue_client.get_session.return_value = {
+            "Session": {"SecurityConfiguration": "my-sec-config"}
+        }
+        glue_client.get_security_configuration.return_value = {
+            "SecurityConfiguration": {
+                "EncryptionConfiguration": {
+                    "S3Encryption": [{"S3EncryptionMode": "SSE-S3"}]
+                }
+            }
+        }
+
+        credentials = GlueCredentials()
+        namespace = None
+        results = []
+        for _ in range(5):  # each iteration is one cursor(): re-init, then query
+            namespace = self._exec_preamble(credentials, glue_client, namespace)
+            results.append(namespace["_get_upload_extra_args"]())
+
+        assert glue_client.get_session.call_count == 1
+        assert glue_client.get_security_configuration.call_count == 1
+        assert all(r == {"ServerSideEncryption": "AES256"} for r in results)
+
+    def test_in_session_clients_are_cached(self) -> None:
+        glue_client = mock.Mock()
+        glue_client.get_session.return_value = {"Session": {}}
+
+        namespace = self._exec_preamble(GlueCredentials(), glue_client)
+
+        assert namespace["_get_glue_client"]() is namespace["_get_glue_client"]()
+        assert namespace["_get_s3_client"]() is namespace["_get_s3_client"]()
+
+    def test_in_session_extra_args_cache_is_not_mutable_by_callers(self) -> None:
+        glue_client = mock.Mock()
+        glue_client.get_session.return_value = {"Session": {}}
+
+        namespace = self._exec_preamble(GlueCredentials(), glue_client)
+
+        first = namespace["_get_upload_extra_args"]()
+        first["ServerSideEncryption"] = "tampered"
+
+        assert namespace["_get_upload_extra_args"]() == {}
+
+    def test_in_session_sse_kms_encryption_args(self) -> None:
+        glue_client = mock.Mock()
+        glue_client.get_session.return_value = {
+            "Session": {"SecurityConfiguration": "my-sec-config"}
+        }
+        glue_client.get_security_configuration.return_value = {
+            "SecurityConfiguration": {
+                "EncryptionConfiguration": {
+                    "S3Encryption": [
+                        {
+                            "S3EncryptionMode": "SSE-KMS",
+                            "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abc-123",
+                        }
+                    ]
+                }
+            }
+        }
+
+        namespace = self._exec_preamble(GlueCredentials(), glue_client)
+
+        assert namespace["_get_upload_extra_args"]() == {
+            "ServerSideEncryption": "aws:kms",
+            "SSEKMSKeyId": "abc-123",
+        }


### PR DESCRIPTION
resolves: #692

### Description

The use_arrow result path resolved the session's SecurityConfiguration on every query, building a fresh boto3 client each time and calling GetSession under botocore's legacy retry policy (4 attempts, no backoff). On busy runs that exhausted the Glue API rate limit:

```
ThrottlingException: An error occurred (ThrottlingException) when calling the GetSession operation (reached max retries: 4): Rate exceeded
```

SecurityConfiguration is fixed for a session's lifetime, so it is now resolved once per session rather than once per query, and the in-session clients are cached and built with the adapter's `boto_retry_mode` / `boto_retry_max_attempts`. Because cursor() re-sends SQLPROXY before every query into the same interpreter, the cache sentinels are initialised only when unset; assigning them unconditionally would drop the cache before each query and leave the call rate unchanged.

Measured on Glue 5.0, 2 x G.1X, eu-central-1, HEAD vs this change:

```
  GetSession       1 per query -> 1 per session
  1 row            351ms -> 259ms  (-26%)
  1k rows x 1KB    396ms -> 270ms  (-32%)
  15k rows x 1KB   733ms -> 658ms  (-10%)
```

Affects use_arrow: true only; the stdout path is unchanged.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.