### PR TITLE
fix: pass file_format to is_incremental()'s get_relation call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## dbt-glue next
 
+- Fixed `is_incremental()` always returning `False` for `file_format='s3tables'` models. dbt-core's built-in `is_incremental()` macro does not pass `file_format` to `adapter.get_relation()`, so relations backed by the S3 Tables catalog could never be resolved. dbt-glue now overrides `is_incremental()` to pass the model's `file_format` through (#620).
 - Fixed `ThrottlingException` on the Glue `GetSession` API when `use_arrow` is enabled. The session's `SecurityConfiguration` is now resolved once per session instead of on every query, the boto3 clients created inside the session are reused, and they honour the profile's `boto_retry_mode` and `boto_retry_max_attempts` instead of botocore's legacy retry policy.
 
 ## v1.12.3

--- a/dbt/include/glue/macros/materializations/incremental/is_incremental.sql
+++ b/dbt/include/glue/macros/materializations/incremental/is_incremental.sql
@@ -1,0 +1,13 @@
+{% macro is_incremental() %}
+    {#-- do not run introspective queries in parsing #}
+    {% if not execute %}
+        {{ return(False) }}
+    {% else %}
+        {#-- pass file_format so relations like s3tables resolve correctly (GitHub #620) #}
+        {% set relation = adapter.get_relation(this.database, this.schema, this.table, config.get('file_format')) %}
+        {{ return(relation is not none
+                  and relation.type == 'table'
+                  and model.config.materialized == 'incremental'
+                  and not should_full_refresh()) }}
+    {% endif %}
+{% endmacro %}

--- a/tests/unit/macros/test_macros.py
+++ b/tests/unit/macros/test_macros.py
@@ -559,3 +559,65 @@ class TestGlueMacros(unittest.TestCase):
         self.assertIn("CompilerError:", str(context.exception))
         self.assertIn("Invalid incremental strategy provided: invalid_strategy", str(context.exception))
         self.assertIn("Expected one of: 'append', 'merge', 'insert_overwrite'", str(context.exception))
+
+    def test_is_incremental_passes_file_format_to_get_relation(self):
+        """is_incremental() must pass the model's file_format to adapter.get_relation()
+        so relations backed by a separate catalog (e.g. s3tables) can be resolved.
+        See GitHub issue #620.
+        """
+        template = self.__get_template("materializations/incremental/is_incremental.sql")
+
+        self.config["file_format"] = "s3tables"
+        self.default_context["execute"] = True
+        self.default_context["model"].config.materialized = "incremental"
+        self.default_context["should_full_refresh"] = lambda: False
+
+        relation = mock.Mock()
+        relation.type = "table"
+        get_relation_calls = []
+
+        def get_relation(database, schema, table, file_format=None):
+            get_relation_calls.append(file_format)
+            return relation
+
+        self.default_context["adapter"].get_relation = get_relation
+
+        result = self.__run_macro(template, "is_incremental")
+
+        # adapter.get_relation must be called with the model's file_format
+        self.assertEqual(get_relation_calls, ["s3tables"])
+        self.assertEqual(result.strip(), "True")
+
+    def test_is_incremental_returns_false_during_parsing(self):
+        """is_incremental() must not run introspective queries during parsing."""
+        template = self.__get_template("materializations/incremental/is_incremental.sql")
+
+        self.default_context["execute"] = False
+        get_relation_calls = []
+
+        def get_relation(database, schema, table, file_format=None):
+            get_relation_calls.append(file_format)
+            return mock.Mock()
+
+        self.default_context["adapter"].get_relation = get_relation
+
+        result = self.__run_macro(template, "is_incremental")
+
+        self.assertEqual(result.strip(), "False")
+        self.assertEqual(get_relation_calls, [])
+
+    def test_is_incremental_returns_false_when_relation_missing(self):
+        """is_incremental() returns False when adapter.get_relation() can't find the
+        relation (e.g. s3tables relation not found because file_format wasn't passed).
+        """
+        template = self.__get_template("materializations/incremental/is_incremental.sql")
+
+        self.config["file_format"] = "s3tables"
+        self.default_context["execute"] = True
+        self.default_context["model"].config.materialized = "incremental"
+        self.default_context["should_full_refresh"] = lambda: False
+        self.default_context["adapter"].get_relation = lambda database, schema, table, file_format=None: None
+
+        result = self.__run_macro(template, "is_incremental")
+
+        self.assertEqual(result.strip(), "False")


### PR DESCRIPTION
resolves #620

### Description

dbt-core's built-in `is_incremental()` macro calls `adapter.get_relation()` without a `file_format` argument, so relations backed by a separate catalog (e.g. `file_format='s3tables'`) can never be resolved and `is_incremental()` always returns `False`.
https://github.com/dbt-labs/dbt-core/blob/50398ecd82f36c6bf0c747b7ee2bfefb3eb97f0f/crates/dbt-loader/src/dbt_macro_assets/dbt-adapters/macros/materializations/models/incremental/is_incremental.sql#L4

Override `is_incremental()` in dbt-glue to pass the model's `file_format` through, so incremental models using `file_format='s3tables'` work as expected.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-glue next" section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.